### PR TITLE
Add Docker infrastructure for running TALES experiments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,8 @@
 !tales/
 !agents/
 !docker/entrypoint.sh
+!docker/templates/
+!docker/templates/**
 
 # Exclude build artifacts within included dirs
 **/__pycache__/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Ignore everything by default
+*
+
+# Only include what's needed for the image
+!requirements.txt
+!pyproject.toml
+!MANIFEST.in
+!benchmark.py
+!print_results.py
+!tales/
+!agents/
+!docker/entrypoint.sh
+
+# Exclude build artifacts within included dirs
+**/__pycache__/
+**/*.pyc
+**/*.egg-info/

--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@
 !print_results.py
 !tales/
 !agents/
+!scripts/
 !docker/entrypoint.sh
 !docker/templates/
 !docker/templates/**

--- a/MODEL_CANDIDATES.md
+++ b/MODEL_CANDIDATES.md
@@ -1,0 +1,140 @@
+# TALES Benchmark — LLM Model Inventory
+
+> Last updated: 2026-05-12
+
+## Models Already Evaluated
+
+### Open-Source — ReAct Agent
+| Model | Runs | Status |
+|-------|------|--------|
+| Qwen/Qwen3-32B | 615 | ✅ done |
+| deepseek-ai/DeepSeek-R1 | 615 | ✅ done |
+| deepseek-ai/DeepSeek-R1-Distill-Llama-70B | 615 | ✅ done |
+| Qwen/Qwen3.6-35B-A3B | 610 | ✅ done |
+| Qwen/Qwen3.5-4B | 610 | ✅ done |
+| deepseek-ai/DeepSeek-V4-Flash | 610 | ✅ done |
+| Qwen/Qwen3.5-0.8B | 610 | ✅ done |
+| Qwen/Qwen3.5-9B | 610 | ✅ done |
+| Qwen/Qwen3.5-2B | 610 | ✅ done |
+| Qwen/Qwen3-30B-A3B | 610 | ✅ done |
+| Qwen/Qwen3.5-27B | 610 | ✅ done |
+| Qwen/Qwen3.6-27B | 610 | ✅ done |
+| MiniMaxAI/MiniMax-M2.7 | 186 | ✅ done |
+| deepseek-ai/DeepSeek-V4-Pro | 7 | 🔄 running |
+| mistralai/Magistral-Small-2506 | 610+ | ✅ done |
+| openai/gpt-oss-120b | 610+ | ✅ done (effort=1024) |
+| openai/gpt-oss-120b (effort=high) | ~360 | 🔄 running (seed 3/5, image 87abc91) |
+| Qwen/Qwen3-235B-A22B | 610+ | ✅ done (4 GPUs) |
+| deepseek-ai/DeepSeek-R1-Distill-Qwen-32B | 610+ | ✅ done |
+
+### Open-Source — Zero-Shot Only
+| Model | Runs |
+|-------|------|
+| meta-llama/Llama-3.2-1B-Instruct | 973 |
+| meta-llama/Llama-3.1-70B-Instruct | 905 |
+| meta-llama/Llama-3.2-3B-Instruct | 895 |
+| meta-llama/Llama-3.1-8B-Instruct | 894 |
+| meta-llama/Llama-3.1-405B-Instruct | 865 |
+| mistralai/Mixtral-8x22B-Instruct-v0.1 | 845 |
+| microsoft/Phi-3-medium-128k-instruct | 843 |
+| mistralai/Mistral-Large-Instruct-2407 | 840 |
+| microsoft/Phi-3.5-mini-instruct | 825 |
+| mistralai/Ministral-8B-Instruct-2410 | 825 |
+| Qwen/Qwen2.5-72B-Instruct | 815 |
+| mistralai/Mistral-Small-Instruct-2409 | 795 |
+| microsoft/Phi-3-mini-128k-instruct | 765 |
+| mistralai/Mixtral-8x7B-Instruct-v0.1 | 645 |
+| meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8 | 615 |
+| meta-llama/Llama-4-Scout-17B-16E-Instruct | 615 |
+| mistralai/Mistral-Small-3.1-24B-Instruct-2503 | 615 |
+| meta-llama/Llama-3.3-70B-Instruct | 615 |
+| microsoft/Phi-3.5-MoE-instruct | 615 |
+| mistralai/Mistral-Small-24B-Instruct-2501 | 615 |
+| microsoft/phi-4 | 615 |
+| microsoft/Phi-4-mini-instruct | 615 |
+| Qwen/Qwen2.5-7B-Instruct | 615 |
+
+### Proprietary Models
+| Model | Runs | Agent |
+|-------|------|-------|
+| o3 | 1847 | react |
+| claude-3.7-sonnet | 1234 | react, zero-shot |
+| claude-opus-4.6 | 983 | react |
+| claude-sonnet-4.6 | 981 | react |
+| claude-haiku-4.5 | 867 | zero-shot |
+| gpt-5.4-nano | 732 | react |
+| gpt-5.1 | 730 | react |
+| gpt-5.4-mini | 721 | react |
+| gpt-4o-mini | 620 | zero-shot |
+| o1 | 616 | react |
+| gpt-4o | 616 | zero-shot |
+| gpt-5 | 615 | react, zero-shot |
+| gpt-5-mini | 615 | react, zero-shot |
+| gpt-4.1 | 615 | zero-shot |
+| gpt-4.1-nano | 615 | zero-shot |
+| gpt-4.1-mini | 615 | zero-shot |
+| gemini-2.0-flash | 615 | zero-shot |
+| claude-3.5-sonnet-latest | 615 | zero-shot |
+| claude-3.5-haiku | 615 | zero-shot |
+| o3-mini | 615 | react |
+| claude-opus-4.5 | 610 | react |
+| claude-sonnet-4.5 | 610 | zero-shot |
+| claude-4-sonnet | 610 | zero-shot |
+| gpt-5-nano | 610 | react |
+| o4-mini | 596 | react |
+| gemini-2.5-pro-preview-03-25 | 594 | react |
+| gpt-5.4 | 446 | react |
+| gpt-5.2 | 52 | react |
+
+---
+
+## Candidates — Not Yet Run
+
+### 🔴 Tier 1 — Must-Run
+
+| # | Model | Active/Total | Type | Thinking | B200 GPUs | License | Why |
+|---|-------|-------------|------|----------|-----------|---------|-----|
+| 1 | deepseek-ai/DeepSeek-R1-0528 | 37B/671B | MoE | ✅ | 4 (FP8) | MIT | Best open reasoning; AIME25 87.5%; supersedes R1 |
+| 2 | microsoft/Phi-4-reasoning-plus | 14B/14B | Dense | ✅ | 1 | MIT | ❌ BROKEN — degenerate infinite thinking loops, never produces actions |
+| 3 | mistralai/Magistral-Small-2506 | 24B/24B | Dense | ✅ | 1 | Apache 2.0 | ✅ DONE |
+| 4 | openai/gpt-oss-120b | 5.1B/117B | MoE (MXFP4) | ✅ | 1 | Apache 2.0 | ✅ DONE (both effort=1024 and effort=high) |
+
+### 🟡 Tier 2 — High Value
+
+| # | Model | Active/Total | Type | Thinking | B200 GPUs | License | Why |
+|---|-------|-------------|------|----------|-----------|---------|-----|
+| 5 | Qwen/Qwen3-235B-A22B | 22B/235B | MoE | ✅ | 4 (64 heads, TP must be 2/4/8) | Apache 2.0 | ✅ DONE (4 GPUs) |
+| 6 | deepseek-ai/DeepSeek-R1-Distill-Qwen-32B | 32B/32B | Dense | ✅ | 1 | MIT | ✅ DONE |
+| 7 | nvidia/Llama-3_3-Nemotron-Super-49B-v1 | 49B/49B | Dense (NAS) | ✅ | 1 | NVIDIA OML | Best 49B; RL-tuned for reasoning+agents |
+| 8 | google/gemma-4-31b-it | 30.7B/30.7B | Dense (hybrid) | ✅ | 1 | Apache 2.0 | 256K ctx; configurable thinking |
+| 9 | Qwen/Qwen3.5-122B-A10B | 10B/122B | MoE (hybrid) | ✅ | 2 | Apache 2.0 | GPQA 86.6%; excellent for ScienceWorld |
+| 10 | zai-org/GLM-5.1 | ~?B/~754B | MoE (DSA) | ✅ | 4-5 (FP8) | Check | HLE 31.0%, AIME26 95.3% |
+| 11 | Qwen/Qwen3.5-397B-A17B | 17B/397B | MoE (hybrid) | ✅ | 5 (FP8: 3) | Apache 2.0 | Flagship Qwen3.5 |
+
+### 🟢 Tier 3 — Coverage / Ablations
+
+| # | Model | Active/Total | Type | Thinking | B200 GPUs | License | Why |
+|---|-------|-------------|------|----------|-----------|---------|-----|
+| 12 | deepseek-ai/DeepSeek-R1-0528-Qwen3-8B | 8B/8B | Dense | ✅ | 1 | MIT | Best 8B reasoning (AIME24 86.0%) |
+| 13 | Qwen/Qwen3-8B | 8B/8B | Dense | ✅ | 1 | Apache 2.0 | Small thinking baseline |
+| 14 | Qwen/Qwen3-14B | 14.8B/14.8B | Dense | ✅ | 1 | Apache 2.0 | 14B thinking model |
+| 15 | openai/gpt-oss-20b | 3.6B/21B | MoE (MXFP4) | ✅ | 1 | Apache 2.0 | Ultra-compact OpenAI reasoning |
+| 16 | nvidia/Llama-3_1-Nemotron-Ultra-253B-v1 | 253B/253B | Dense (NAS) | ✅ | 3 (FP8: 2) | NVIDIA OML | Frontier non-MoE reasoning |
+| 17 | nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning | 3B/31B | MoE (Mamba2) | ✅ | 1 | NVIDIA OML | Mamba2 hybrid; fastest inference |
+| 18 | poolside/Laguna-XS.2 | 3B/33B | MoE (hybrid) | ✅ | 1 | Apache 2.0 | Interleaved thinking between tool calls |
+| 19 | moonshotai/Kimi-K2-Instruct | 32B/1T | MoE (MLA) | ❌ | 6 (FP8) | Modified MIT | 1T frontier; best open agentic tool-use |
+| 20 | XiaomiMiMo/MiMo-V2.5-Pro | 42B/1.02T | MoE (hybrid) | ✅ | 6 (FP8) | Apache 2.0 | 1M ctx; pure RL reasoning |
+| 21 | mistralai/Magistral-Medium-2506 | ~123B/~123B | Dense | ✅ | 2 | Mistral Research | 123B reasoning |
+| 22 | Qwen/Qwen3.5-35B-A3B | 3B/35B | MoE (hybrid) | ✅ | 1 | Apache 2.0 | Distinct from already-run Qwen3.6-35B-A3B |
+| 23 | tencent/Hy3-preview | 21B/295B | MoE | ✅ | 4 (FP8: 2) | Tencent Hy | 295B MoE reasoning |
+| 24 | inclusionAI/Ling-2.6-flash | 7.4B/104B | MoE (MLA+Linear) | ✅ | 2 | Open | Fast token-efficient |
+| 25 | CohereLabs/c4ai-command-a-03-2025 | 111B/111B | Dense (hybrid) | ❌ | 2 | CC-BY-NC | Enterprise RAG/agentic |
+
+---
+
+## Notes
+- **GPU estimates** assume B200 192GB. "FP8: N" means N GPUs with FP8 quantization.
+- **openai/gpt-oss-\*** may require a custom vLLM fork — verify compatibility before deploying.
+- **DeepSeek-R1-0528** now supports system prompts (unlike original R1).
+- **Tier 1** has 3 of 4 models fitting on a single B200 — fastest to evaluate.
+- Several **zero-shot-only** models (Llama-4-Scout, Maverick, Llama-3.3-70B) could be re-run with react agent if desired.

--- a/agents/random.py
+++ b/agents/random.py
@@ -40,9 +40,6 @@ class RandomAgent(tales.Agent):
             "prompt": None,
             "response": None,
             "nb_tokens": self.token_counter(text=obs),
-            "nb_tokens_prompt": self.token_counter(text=obs),
-            "nb_tokens_response": 0,
-            "nb_tokens_thinking": 0,
         }
 
         if "admissible_commands" in info:

--- a/agents/reasoning.py
+++ b/agents/reasoning.py
@@ -197,6 +197,12 @@ class ReasoningAgent(tales.Agent):
             # For these models, we cannot set the seed and max_tokens has a different name.
             llm_kwargs.pop("seed")
 
+        # For open models served via vLLM/SGLang, enable thinking mode explicitly.
+        if self.llm not in OPENAI_MODELS + CLAUDE_MODELS + GEMINI_MODELS:
+            llm_kwargs["extra_body"] = {
+                "chat_template_kwargs": {"enable_thinking": True}
+            }
+
         messages = self.build_messages(f"{obs}\n> ")
         response = self._llm_call_from_messages(messages, **llm_kwargs)
         response_text = response.text()

--- a/agents/reasoning.py
+++ b/agents/reasoning.py
@@ -27,6 +27,17 @@ SYSTEM_PROMPT = (
     " When stuck, try using the `help` command to see what commands are available."
 )
 
+# Suffix appended to the system prompt for models that need explicit
+# thinking instructions (e.g. Magistral, which uses a native Mistral
+# tokenizer and doesn't auto-inject thinking via chat template).
+THINKING_INSTRUCTION = (
+    "\n\nYour thinking process must follow the template below:\n"
+    "<think>\n"
+    "Your thoughts or draft.\n"
+    "</think>\n\n"
+    "After thinking, provide ONLY the game command."
+)
+
 DEEPSEEK_CHAT_TEMPLATE_NO_THINK = "{% if not add_generation_prompt is defined %}{% set add_generation_prompt = false %}{% endif %}{% set ns = namespace(is_first=false, is_tool=false, is_output_first=true, system_prompt='') %}{%- for message in messages %}{%- if message['role'] == 'system' %}{% set ns.system_prompt = message['content'] %}{%- endif %}{%- endfor %}{{bos_token}}{{ns.system_prompt}}{%- for message in messages %}{%- if message['role'] == 'user' %}{%- set ns.is_tool = false -%}{{'<｜User｜>' + message['content']}}{%- endif %}{%- if message['role'] == 'assistant' and message['content'] is none %}{%- set ns.is_tool = false -%}{%- for tool in message['tool_calls']%}{%- if not ns.is_first %}{{'<｜Assistant｜><｜tool▁calls▁begin｜><｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '\\n' + '```json' + '\\n' + tool['function']['arguments'] + '\\n' + '```' + '<｜tool▁call▁end｜>'}}{%- set ns.is_first = true -%}{%- else %}{{'\\n' + '<｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '\\n' + '```json' + '\\n' + tool['function']['arguments'] + '\\n' + '```' + '<｜tool▁call▁end｜>'}}{{'<｜tool▁calls▁end｜><｜end▁of▁sentence｜>'}}{%- endif %}{%- endfor %}{%- endif %}{%- if message['role'] == 'assistant' and message['content'] is not none %}{%- if ns.is_tool %}{{'<｜tool▁outputs▁end｜>' + message['content'] + '<｜end▁of▁sentence｜>'}}{%- set ns.is_tool = false -%}{%- else %}{% set content = message['content'] %}{% if '</think>' in content %}{% set content = content.split('</think>')[-1] %}{% endif %}{{'<｜Assistant｜>' + content + '<｜end▁of▁sentence｜>'}}{%- endif %}{%- endif %}{%- if message['role'] == 'tool' %}{%- set ns.is_tool = true -%}{%- if ns.is_output_first %}{{'<｜tool▁outputs▁begin｜><｜tool▁output▁begin｜>' + message['content'] + '<｜tool▁output▁end｜>'}}{%- set ns.is_output_first = false %}{%- else %}{{'\\n<｜tool▁output▁begin｜>' + message['content'] + '<｜tool▁output▁end｜>'}}{%- endif %}{%- endif %}{%- endfor -%}{% if ns.is_tool %}{{'<｜tool▁outputs▁end｜>'}}{% endif %}{% if add_generation_prompt and not ns.is_tool %}{{'<｜Assistant｜><think>\\n</think>\\n'}}{% endif %}"
 
 CLAUDE_MODELS = [
@@ -140,10 +151,6 @@ class ReasoningAgent(tales.Agent):
             "reasoning_effort": self.reasoning_effort,
         }
 
-    def _is_mistral_native(self):
-        """Check if current model uses Mistral native tokenizer."""
-        return any(m in self.llm for m in MISTRAL_NATIVE_MODELS)
-
     @retry(
         retry=retry_if_exception(is_recoverable_error),
         wait=wait_random_exponential(multiplier=1, max=40),
@@ -151,8 +158,6 @@ class ReasoningAgent(tales.Agent):
     )
     def _llm_call_from_conversation(self, conversation, *args, **kwargs):
         extra_body = kwargs.pop("extra_body", None)
-        patches_applied = []
-
         if extra_body:
             # Monkey-patch model.build_kwargs to inject extra_body into API call
             original_build_kwargs = self.model.__class__.build_kwargs
@@ -163,7 +168,6 @@ class ReasoningAgent(tales.Agent):
                 return result
 
             self.model.__class__.build_kwargs = patched_build_kwargs
-            patches_applied.append(("build_kwargs", original_build_kwargs))
 
         try:
             for i in range(10):
@@ -171,22 +175,12 @@ class ReasoningAgent(tales.Agent):
                 response.duration_ms()  # Forces the response to be computed.
                 if response.text():
                     return response  # Non-empty response, otherwise retry.
-                # For Mistral models with reasoning parser, the model may return
-                # reasoning but empty content. Accept if reasoning is present.
-                if self._is_mistral_native():
-                    rj = response.response_json
-                    if isinstance(rj, dict):
-                        choices = rj.get("choices", [])
-                        if choices:
-                            msg = choices[0].get("message", {})
-                            if msg.get("reasoning") or msg.get("reasoning_content"):
-                                return response
                 # Remove the failed empty response from conversation to prevent accumulation
                 if conversation.responses:
                     conversation.responses.pop()
         finally:
-            for attr, original in reversed(patches_applied):
-                setattr(self.model.__class__, attr, original)
+            if extra_body:
+                self.model.__class__.build_kwargs = original_build_kwargs
 
         return response  # Return last response even if empty
 
@@ -233,37 +227,18 @@ class ReasoningAgent(tales.Agent):
             llm_kwargs.pop("seed")
 
         # For open models served via vLLM/SGLang, enable thinking mode explicitly.
-        # Skip for Mistral-native models (they use --enable-reasoning at server level).
+        # Magistral/Mistral-native models use a non-Jinja2 tokenizer that doesn't
+        # support chat_template_kwargs — they produce <think> tags naturally.
         if self.llm not in OPENAI_MODELS + CLAUDE_MODELS + GEMINI_MODELS:
-            if self._is_mistral_native():
-                # Mistral uses vLLM's reasoning parser: thinking goes to the
-                # `reasoning` field. Use non-streaming so response_json has
-                # the full completion structure (streaming loses reasoning in
-                # combine_chunks). 24B model on B200 is fast enough.
-                llm_kwargs["stream"] = False
-            else:
+            if not any(m in self.llm for m in MISTRAL_NATIVE_MODELS):
                 llm_kwargs["extra_body"] = {
                     "chat_template_kwargs": {"enable_thinking": True}
                 }
 
         messages = self.build_messages(f"{obs}\n> ")
         response = self._llm_call_from_messages(messages, **llm_kwargs)
-        response_text = response.text() or ""
-        action = response_text.strip()
-
-        # For models using vLLM's reasoning parser (e.g., Mistral), thinking
-        # is in the `reasoning` field of the API response, not in `content`.
-        # Reconstruct <think>...</think> wrapper so existing parsing handles it.
-        if self._is_mistral_native():
-            rj = response.json()
-            if isinstance(rj, dict):
-                choices = rj.get("choices", [])
-                if choices:
-                    msg = choices[0].get("message", {})
-                    reasoning = msg.get("reasoning") or msg.get("reasoning_content")
-                    if reasoning:
-                        action = f"<think>{reasoning}</think>{action}"
-                        response_text = action
+        response_text = response.text()
+        action = response.text().strip()
 
         if action == "":
             # If the action is empty, we need to retry.
@@ -302,6 +277,21 @@ class ReasoningAgent(tales.Agent):
                     }
                     response = self._llm_call_from_messages(messages, **llm_kwargs)
                     response_text += "\n" + response.text()
+                    action = response.text().strip()
+                elif any(m in self.llm for m in MISTRAL_NATIVE_MODELS):
+                    # Mistral-native: just ask for action without thinking
+                    messages.append(
+                        {
+                            "role": "assistant",
+                            "content": response_text.strip() + "</think>",
+                        }
+                    )
+                    messages.append({"role": "user", "content": "> "})
+                    llm_kwargs["max_tokens"] = 100
+                    llm_kwargs["temperature"] = self.act_temp
+                    llm_kwargs.pop("extra_body", None)
+                    response = self._llm_call_from_messages(messages, **llm_kwargs)
+                    response_text += "</think>" + response.text()
                     action = response.text().strip()
                 else:
                     # Generic: use chat_template_kwargs (Qwen3, MiniMax, etc.)
@@ -389,7 +379,13 @@ class ReasoningAgent(tales.Agent):
         return action, stats
 
     def build_messages(self, observation):
-        messages = [{"role": "system", "content": SYSTEM_PROMPT}]
+        system_prompt = SYSTEM_PROMPT
+        # Magistral/Mistral-native models need explicit thinking instructions
+        # since their tokenizer doesn't inject them via chat template.
+        if any(m in self.llm for m in MISTRAL_NATIVE_MODELS):
+            system_prompt += THINKING_INSTRUCTION
+
+        messages = [{"role": "system", "content": system_prompt}]
         limit = self.context_limit or len(self.history) + 1
 
         for i, (obs, action) in enumerate(self.history[-limit:]):
@@ -414,7 +410,7 @@ class ReasoningAgent(tales.Agent):
 
         if not self.allows_system_prompt:
             # Make sure the system prompt is added to the following message.
-            messages[1]["content"] = f"{SYSTEM_PROMPT}\n\n{messages[1]['content']}"
+            messages[1]["content"] = f"{system_prompt}\n\n{messages[1]['content']}"
             messages.pop(0)
 
         return messages

--- a/agents/reasoning.py
+++ b/agents/reasoning.py
@@ -1,4 +1,5 @@
 import argparse
+import re
 
 import llm
 import numpy as np
@@ -38,6 +39,14 @@ CLAUDE_MODELS = [
     "claude-sonnet-4.6",
 ]
 
+# Capture every <think>…</think> block so we can strip ALL of them from
+# the final action.  Some chat templates (notably MiniMax-M2.5 with
+# ``enable_thinking: True``) emit an empty ``<think></think>`` immediately
+# followed by the model's *real* think block then the action — a single
+# pass that stops at the first ``</think>`` would leak the second block
+# into the action and the game would reject the multi-line input.
+_THINK_RE = re.compile(r"<think>(.*?)</think>", re.DOTALL)
+
 OPENAI_MODELS = [
     "o1",
     "o1-mini",
@@ -57,6 +66,15 @@ OPENAI_MODELS = [
 GEMINI_MODELS = [
     "gemini-2.5-pro",
     "gemini-3-pro-preview",
+]
+
+# Models using Mistral native tokenizer — don't support chat_template_kwargs.
+# Thinking is handled via --enable-reasoning --reasoning-parser at the server level
+# and surfaces in the API response's `reasoning` field.
+MISTRAL_NATIVE_MODELS = [
+    "Magistral",
+    "Mistral-Small-3",
+    "Mistral-Large",
 ]
 
 
@@ -122,6 +140,10 @@ class ReasoningAgent(tales.Agent):
             "reasoning_effort": self.reasoning_effort,
         }
 
+    def _is_mistral_native(self):
+        """Check if current model uses Mistral native tokenizer."""
+        return any(m in self.llm for m in MISTRAL_NATIVE_MODELS)
+
     @retry(
         retry=retry_if_exception(is_recoverable_error),
         wait=wait_random_exponential(multiplier=1, max=40),
@@ -129,6 +151,8 @@ class ReasoningAgent(tales.Agent):
     )
     def _llm_call_from_conversation(self, conversation, *args, **kwargs):
         extra_body = kwargs.pop("extra_body", None)
+        patches_applied = []
+
         if extra_body:
             # Monkey-patch model.build_kwargs to inject extra_body into API call
             original_build_kwargs = self.model.__class__.build_kwargs
@@ -139,6 +163,7 @@ class ReasoningAgent(tales.Agent):
                 return result
 
             self.model.__class__.build_kwargs = patched_build_kwargs
+            patches_applied.append(("build_kwargs", original_build_kwargs))
 
         try:
             for i in range(10):
@@ -146,12 +171,22 @@ class ReasoningAgent(tales.Agent):
                 response.duration_ms()  # Forces the response to be computed.
                 if response.text():
                     return response  # Non-empty response, otherwise retry.
+                # For Mistral models with reasoning parser, the model may return
+                # reasoning but empty content. Accept if reasoning is present.
+                if self._is_mistral_native():
+                    rj = response.response_json
+                    if isinstance(rj, dict):
+                        choices = rj.get("choices", [])
+                        if choices:
+                            msg = choices[0].get("message", {})
+                            if msg.get("reasoning") or msg.get("reasoning_content"):
+                                return response
                 # Remove the failed empty response from conversation to prevent accumulation
                 if conversation.responses:
                     conversation.responses.pop()
         finally:
-            if extra_body:
-                self.model.__class__.build_kwargs = original_build_kwargs
+            for attr, original in reversed(patches_applied):
+                setattr(self.model.__class__, attr, original)
 
         return response  # Return last response even if empty
 
@@ -198,15 +233,37 @@ class ReasoningAgent(tales.Agent):
             llm_kwargs.pop("seed")
 
         # For open models served via vLLM/SGLang, enable thinking mode explicitly.
+        # Skip for Mistral-native models (they use --enable-reasoning at server level).
         if self.llm not in OPENAI_MODELS + CLAUDE_MODELS + GEMINI_MODELS:
-            llm_kwargs["extra_body"] = {
-                "chat_template_kwargs": {"enable_thinking": True}
-            }
+            if self._is_mistral_native():
+                # Mistral uses vLLM's reasoning parser: thinking goes to the
+                # `reasoning` field. Use non-streaming so response_json has
+                # the full completion structure (streaming loses reasoning in
+                # combine_chunks). 24B model on B200 is fast enough.
+                llm_kwargs["stream"] = False
+            else:
+                llm_kwargs["extra_body"] = {
+                    "chat_template_kwargs": {"enable_thinking": True}
+                }
 
         messages = self.build_messages(f"{obs}\n> ")
         response = self._llm_call_from_messages(messages, **llm_kwargs)
-        response_text = response.text()
-        action = response.text().strip()
+        response_text = response.text() or ""
+        action = response_text.strip()
+
+        # For models using vLLM's reasoning parser (e.g., Mistral), thinking
+        # is in the `reasoning` field of the API response, not in `content`.
+        # Reconstruct <think>...</think> wrapper so existing parsing handles it.
+        if self._is_mistral_native():
+            rj = response.json()
+            if isinstance(rj, dict):
+                choices = rj.get("choices", [])
+                if choices:
+                    msg = choices[0].get("message", {})
+                    reasoning = msg.get("reasoning") or msg.get("reasoning_content")
+                    if reasoning:
+                        action = f"<think>{reasoning}</think>{action}"
+                        response_text = action
 
         if action == "":
             # If the action is empty, we need to retry.
@@ -215,8 +272,18 @@ class ReasoningAgent(tales.Agent):
         # --- Extract thinking from <think> tags (generic for all open models) ---
         thinking = None
         if "<think>" in action or "</think>" in action:
-            reasoning_end = action.find("</think>")
-            if reasoning_end == -1:
+            # First pass: strip every closed <think>…</think> block.  Some
+            # chat templates emit an empty ``<think></think>`` *and* the
+            # real one; we must take all of them, not just the first.
+            closed_blocks = _THINK_RE.findall(action)
+            if closed_blocks:
+                non_empty = [b.strip() for b in closed_blocks if b.strip()]
+                thinking = "\n\n".join(non_empty) if non_empty else ""
+                action = _THINK_RE.sub("", action).strip()
+            # If after stripping there's still an unclosed <think> tag
+            # (token budget exhausted mid-thought), fall through to the
+            # follow-up call below.
+            if "<think>" in action and "</think>" not in action:
                 # Thinking exceeded token budget — send follow-up to get action.
                 if "DeepSeek-R1" in self.llm:
                     # DeepSeek requires a custom chat template to suppress thinking.
@@ -236,13 +303,6 @@ class ReasoningAgent(tales.Agent):
                     response = self._llm_call_from_messages(messages, **llm_kwargs)
                     response_text += "\n" + response.text()
                     action = response.text().strip()
-                    reasoning_end = action.find("</think>")
-                    if reasoning_end == -1:
-                        reasoning_end = (
-                            0  # Give up and use the entire response as the action.
-                        )
-                    else:
-                        reasoning_end += len("</think>")
                 else:
                     # Generic: use chat_template_kwargs (Qwen3, MiniMax, etc.)
                     messages.append(
@@ -259,13 +319,17 @@ class ReasoningAgent(tales.Agent):
                     }
                     response = self._llm_call_from_messages(messages, **llm_kwargs)
                     response_text += "</think>" + response.text()
-                    action = response_text.strip()
-                    reasoning_end = action.find("</think>") + len("</think>")
-            else:
-                reasoning_end += len("</think>")
-
-            thinking = action[:reasoning_end].strip()
-            action = action[reasoning_end:].strip()
+                    action = response.text().strip()
+                # Re-strip any think blocks that came back in the follow-up.
+                followup_blocks = _THINK_RE.findall(action)
+                if followup_blocks:
+                    fu_non_empty = [b.strip() for b in followup_blocks if b.strip()]
+                    if fu_non_empty:
+                        joined = "\n\n".join(fu_non_empty)
+                        thinking = (
+                            (thinking + "\n\n" + joined).strip() if thinking else joined
+                        )
+                    action = _THINK_RE.sub("", action).strip()
 
         elif self.llm in CLAUDE_MODELS:
             # Extract the thinking part from the response JSON.

--- a/agents/reasoning.py
+++ b/agents/reasoning.py
@@ -260,6 +260,15 @@ class ReasoningAgent(tales.Agent):
             # follow-up call below.
             if "<think>" in action and "</think>" not in action:
                 # Thinking exceeded token budget — send follow-up to get action.
+                # Capture the unclosed thinking content before recovery.
+                _idx = action.index("<think>") + len("<think>")
+                _unclosed = action[_idx:].strip()
+                if _unclosed:
+                    thinking = (
+                        (thinking + "\n\n" + _unclosed).strip()
+                        if thinking
+                        else _unclosed
+                    )
                 if "DeepSeek-R1" in self.llm:
                     # DeepSeek requires a custom chat template to suppress thinking.
                     messages.append(
@@ -327,7 +336,15 @@ class ReasoningAgent(tales.Agent):
                 [item.get("thinking", "") for item in response.json()["content"]]
             )
 
-        self.history.append((f"{obs}\n> ", f"{action}\n"))
+        # For Mistral-native models, keep a short thinking stub in history so
+        # the model sees the <think> pattern and continues to reason on later
+        # turns.  Full thinking would bloat context (~1 KiB/step × 100 steps).
+        if any(m in self.llm for m in MISTRAL_NATIVE_MODELS) and thinking:
+            stub = thinking[:120].rsplit(" ", 1)[0] + "..."
+            history_action = f"<think>\n{stub}\n</think>\n{action}\n"
+        else:
+            history_action = f"{action}\n"
+        self.history.append((f"{obs}\n> ", history_action))
 
         # Compute usage statistics
         stats = {

--- a/agents/reasoning.py
+++ b/agents/reasoning.py
@@ -212,7 +212,7 @@ class ReasoningAgent(tales.Agent):
             reasoning_end = action.find("</think>")
             if reasoning_end == -1:
                 # Thinking exceeded token budget — send follow-up to get action.
-                if "DeepSeek-R1" in self.llm or "DeepSeek-V4" in self.llm:
+                if "DeepSeek-R1" in self.llm:
                     # DeepSeek requires a custom chat template to suppress thinking.
                     messages.append(
                         {

--- a/agents/reasoning.py
+++ b/agents/reasoning.py
@@ -1,8 +1,10 @@
 import argparse
+import os
 import re
 
 import llm
 import numpy as np
+from openai import OpenAI
 from tenacity import (
     retry,
     retry_if_exception,
@@ -57,6 +59,7 @@ CLAUDE_MODELS = [
 # pass that stops at the first ``</think>`` would leak the second block
 # into the action and the game would reject the multi-line input.
 _THINK_RE = re.compile(r"<think>(.*?)</think>", re.DOTALL)
+_GEMMA_CHANNEL_RE = re.compile(r"<\|channel>thought\n(.*?)<channel\|>", re.DOTALL)
 
 OPENAI_MODELS = [
     "o1",
@@ -126,6 +129,22 @@ class ReasoningAgent(tales.Agent):
         self.reasoning_effort = reasoning_effort
         self.conversation = kwargs["conversation"]
 
+        # Detect vLLM-served models and use OpenAI client directly.
+        # The `llm` library doesn't expose message.reasoning_content,
+        # which vLLM populates when --reasoning-parser is configured.
+        server_type = os.environ.get("SERVER_TYPE", "vllm")
+        self.server_url = os.environ.get("SERVER_URL") or os.environ.get("VLLM_URL")
+        self.reasoning_parser = os.environ.get("REASONING_PARSER")
+        self.use_vllm_client = (
+            self.server_url is not None
+            and server_type == "vllm"
+            and self.llm not in OPENAI_MODELS + CLAUDE_MODELS + GEMINI_MODELS
+        )
+        self._is_gptoss = "gpt-oss" in self.llm.lower()
+        if self.use_vllm_client:
+            api_key = os.environ.get("OPENAI_API_KEY", "not-needed")
+            self.client = OpenAI(base_url=self.server_url, api_key=api_key)
+
     @property
     def uid(self):
         return (
@@ -193,7 +212,154 @@ class ReasoningAgent(tales.Agent):
             conversation, prompt=prompt, system=system, *args, **kwargs
         )
 
+    @retry(
+        retry=retry_if_exception(is_recoverable_error),
+        wait=wait_random_exponential(multiplier=1, max=40),
+        stop=stop_after_attempt(100),
+    )
+    def _vllm_call(self, messages, **kwargs):
+        """Call vLLM-served model via OpenAI-compatible client."""
+        for _ in range(10):
+            response = self.client.chat.completions.create(
+                model=self.llm,
+                messages=messages,
+                **kwargs,
+            )
+            content = response.choices[0].message.content or ""
+            if content.strip():
+                return response
+        return response
+
+    def _act_vllm(self, messages):
+        """Act using the vLLM OpenAI-compatible client (accesses reasoning field)."""
+        kwargs = {"temperature": self.cot_temp, "seed": self.seed}
+        extra_body = {}
+
+        if self._is_gptoss:
+            # gpt-oss: template-level reasoning effort control (Harmony channels)
+            extra_body["chat_template_kwargs"] = {"reasoning_effort": "high"}
+        else:
+            is_mistral = any(m in self.llm for m in MISTRAL_NATIVE_MODELS)
+            # Models using prompt-based thinking (no parser) don't need
+            # enable_thinking — it can confuse templates that don't support it.
+            uses_prompt_thinking = "nemotron" in self.llm.lower()
+            if not is_mistral and not uses_prompt_thinking:
+                extra_body.setdefault("chat_template_kwargs", {})[
+                    "enable_thinking"
+                ] = True
+            if isinstance(self.reasoning_effort, int) and self.reasoning_parser:
+                extra_body["thinking_token_budget"] = self.reasoning_effort
+
+        # Gemma4: vLLM parser bug strips channel tokens; request them back
+        is_gemma4 = "gemma-4" in self.llm.lower() or "gemma4" in self.llm.lower()
+        if is_gemma4:
+            extra_body["skip_special_tokens"] = False
+
+        if isinstance(self.reasoning_effort, int):
+            kwargs["max_tokens"] = self.reasoning_effort + 512
+        else:
+            kwargs["max_tokens"] = 2048
+
+        if extra_body:
+            kwargs["extra_body"] = extra_body
+
+        response = self._vllm_call(messages, **kwargs)
+        msg = response.choices[0].message
+
+        # Extract thinking from API reasoning field (populated by --reasoning-parser).
+        # vLLM versions use either "reasoning" or "reasoning_content".
+        thinking = (
+            getattr(msg, "reasoning", None)
+            or getattr(msg, "reasoning_content", None)
+            or None
+        )
+        action = (msg.content or "").strip()
+
+        # Fallback: parse <think> tags if no reasoning from API
+        if thinking is None and ("<think>" in action or "</think>" in action):
+            closed_blocks = _THINK_RE.findall(action)
+            if closed_blocks:
+                non_empty = [b.strip() for b in closed_blocks if b.strip()]
+                thinking = "\n\n".join(non_empty) if non_empty else ""
+                action = _THINK_RE.sub("", action).strip()
+            elif "</think>" in action:
+                # Template-injected <think>: only </think> in output
+                parts = action.split("</think>", 1)
+                thinking = parts[0].strip()
+                action = parts[1].strip() if len(parts) > 1 else ""
+
+        # Fallback: gemma4 channel tokens (vLLM parser bug in v0.20.0)
+        if thinking is None and "<|channel>" in action:
+            m = _GEMMA_CHANNEL_RE.search(action)
+            if m:
+                thinking = m.group(1).strip()
+                action = _GEMMA_CHANNEL_RE.sub("", action).strip()
+                # Clean remaining special tokens from action
+                for tag in ("<|channel>", "<channel|>", "<|turn>", "<turn|>"):
+                    action = action.replace(tag, "")
+                action = action.strip()
+
+        # Recovery: if token budget exhausted with no action, follow-up call
+        if not action and response.choices[0].finish_reason == "length":
+            follow_up = messages.copy()
+            if thinking:
+                follow_up.append(
+                    {"role": "assistant", "content": f"<think>\n{thinking}\n</think>"}
+                )
+            follow_up.append({"role": "user", "content": "> "})
+            recovery_kwargs = {
+                "temperature": self.act_temp,
+                "seed": self.seed,
+                "max_tokens": 100,
+            }
+            is_mistral = any(m in self.llm for m in MISTRAL_NATIVE_MODELS)
+            if not is_mistral and not self._is_gptoss:
+                recovery_kwargs["extra_body"] = {
+                    "chat_template_kwargs": {"enable_thinking": False}
+                }
+            recovery = self._vllm_call(follow_up, **recovery_kwargs)
+            action = (recovery.choices[0].message.content or "").strip()
+            action = _THINK_RE.sub("", action).strip()
+
+        if not action:
+            action = "(empty)"
+
+        # Compute usage statistics
+        usage = response.usage
+        response_text = msg.content or ""
+        stats = {
+            "prompt": format_messages_to_markdown(messages),
+            "thinking": thinking,
+            "response": response_text,
+            "nb_tokens_prompt": usage.prompt_tokens if usage else 0,
+            "nb_tokens_thinking": self.token_counter(text=thinking) if thinking else 0,
+            "nb_tokens_response": usage.completion_tokens if usage else 0,
+        }
+        stats["nb_tokens"] = (
+            stats["nb_tokens_prompt"]
+            + stats["nb_tokens_response"]
+            + stats["nb_tokens_thinking"]
+        )
+
+        return action, thinking, stats
+
     def act(self, obs, reward, done, infos):
+        # --- vLLM path: use OpenAI client to access reasoning field ---
+        if self.use_vllm_client:
+            messages = self.build_messages(f"{obs}\n> ")
+            action, thinking, stats = self._act_vllm(messages)
+
+            # History management
+            if any(m in self.llm for m in MISTRAL_NATIVE_MODELS) and thinking:
+                stub = thinking[:120].rsplit(" ", 1)[0] + "..."
+                history_action = f"<think>\n{stub}\n</think>\n{action}\n"
+            else:
+                history_action = f"{action}\n"
+            self.history.append((f"{obs}\n> ", history_action))
+
+            return action, stats
+
+        # --- Existing llm library path (API models: OpenAI, Claude, Gemini) ---
         llm_kwargs = {
             "temperature": self.cot_temp,
             "seed": self.seed,
@@ -255,6 +421,11 @@ class ReasoningAgent(tales.Agent):
                 non_empty = [b.strip() for b in closed_blocks if b.strip()]
                 thinking = "\n\n".join(non_empty) if non_empty else ""
                 action = _THINK_RE.sub("", action).strip()
+            elif "</think>" in action:
+                # Template-injected <think>: only </think> in output
+                parts = action.split("</think>", 1)
+                thinking = parts[0].strip()
+                action = parts[1].strip() if len(parts) > 1 else ""
             # If after stripping there's still an unclosed <think> tag
             # (token budget exhausted mid-thought), fall through to the
             # follow-up call below.
@@ -397,9 +568,13 @@ class ReasoningAgent(tales.Agent):
 
     def build_messages(self, observation):
         system_prompt = SYSTEM_PROMPT
-        # Magistral/Mistral-native models need explicit thinking instructions
-        # since their tokenizer doesn't inject them via chat template.
-        if any(m in self.llm for m in MISTRAL_NATIVE_MODELS):
+        # Models that need explicit thinking instructions in the prompt
+        # because their tokenizer/template doesn't inject them automatically.
+        needs_think_instruction = (
+            any(m in self.llm for m in MISTRAL_NATIVE_MODELS)
+            or "nemotron" in self.llm.lower()
+        )
+        if needs_think_instruction:
             system_prompt += THINKING_INSTRUCTION
 
         messages = [{"role": "system", "content": system_prompt}]

--- a/agents/reasoning.py
+++ b/agents/reasoning.py
@@ -206,77 +206,59 @@ class ReasoningAgent(tales.Agent):
             # If the action is empty, we need to retry.
             action = "(empty)"
 
+        # --- Extract thinking from <think> tags (generic for all open models) ---
         thinking = None
-        if "Qwen3" in self.llm:
-            # Strip the reasoning <think> and </think>.
+        if "<think>" in action or "</think>" in action:
             reasoning_end = action.find("</think>")
             if reasoning_end == -1:
-                # Send another request to get the action with the current reasoning.
-                messages.append(
-                    {
-                        "role": "assistant",
-                        "content": response_text.strip() + "</think>",
-                    }
-                )
-                messages.append(
-                    {
-                        "role": "user",
-                        "content": "> ",
-                    }
-                )
-                llm_kwargs["max_tokens"] = 100  # Text actions should be short phrases.
-                llm_kwargs["temperature"] = self.act_temp
-                llm_kwargs["extra_body"] = {
-                    "chat_template_kwargs": {"enable_thinking": False}
-                }
-                response = self._llm_call_from_messages(messages, **llm_kwargs)
-                response_text += "</think>" + response.text()
-                action = response_text.strip()
-                reasoning_end = action.find("</think>") + len("</think>")
-            else:
-                reasoning_end += len("</think>")
-
-            # Extract the reasoning part from the response.
-            thinking = action[:reasoning_end].strip()
-            # Extract the action part from the response.
-            action = action[reasoning_end:].strip()
-
-        if "DeepSeek-R1" in self.llm or "DeepSeek-V4" in self.llm:
-            # Strip the reasoning <think> and </think>.
-            reasoning_end = action.find("</think>")
-            if reasoning_end == -1:
-                # Send another request to get the action with the current reasoning.
-                messages.append(
-                    {
-                        "role": "assistant",
-                        "content": "<think>\n" + response_text.strip() + "\n</think>",
-                    }
-                )
-                # prompt = "// Thinking exceeded the length limit. Based on the thoughts so far, provide your chosen action on a single line while respecting the desired format.\n> "
-                # messages.append({"role": "user", "content": prompt})
-                llm_kwargs["max_tokens"] = (
-                    100  # Text actions should be short phrases but deepseek forces thought process by starting the generation with <think>.
-                )
-                llm_kwargs["temperature"] = self.act_temp
-                llm_kwargs["extra_body"] = {
-                    "chat_template": DEEPSEEK_CHAT_TEMPLATE_NO_THINK,
-                }
-                response = self._llm_call_from_messages(messages, **llm_kwargs)
-                response_text += "\n" + response.text()
-                action = response.text().strip()
-                reasoning_end = action.find("</think>")
-                if reasoning_end == -1:
-                    reasoning_end = (
-                        0  # Give up and use the entire response as the action.
+                # Thinking exceeded token budget — send follow-up to get action.
+                if "DeepSeek-R1" in self.llm or "DeepSeek-V4" in self.llm:
+                    # DeepSeek requires a custom chat template to suppress thinking.
+                    messages.append(
+                        {
+                            "role": "assistant",
+                            "content": "<think>\n"
+                            + response_text.strip()
+                            + "\n</think>",
+                        }
                     )
+                    llm_kwargs["max_tokens"] = 100
+                    llm_kwargs["temperature"] = self.act_temp
+                    llm_kwargs["extra_body"] = {
+                        "chat_template": DEEPSEEK_CHAT_TEMPLATE_NO_THINK,
+                    }
+                    response = self._llm_call_from_messages(messages, **llm_kwargs)
+                    response_text += "\n" + response.text()
+                    action = response.text().strip()
+                    reasoning_end = action.find("</think>")
+                    if reasoning_end == -1:
+                        reasoning_end = (
+                            0  # Give up and use the entire response as the action.
+                        )
+                    else:
+                        reasoning_end += len("</think>")
                 else:
-                    reasoning_end += len("</think>")
+                    # Generic: use chat_template_kwargs (Qwen3, MiniMax, etc.)
+                    messages.append(
+                        {
+                            "role": "assistant",
+                            "content": response_text.strip() + "</think>",
+                        }
+                    )
+                    messages.append({"role": "user", "content": "> "})
+                    llm_kwargs["max_tokens"] = 100
+                    llm_kwargs["temperature"] = self.act_temp
+                    llm_kwargs["extra_body"] = {
+                        "chat_template_kwargs": {"enable_thinking": False}
+                    }
+                    response = self._llm_call_from_messages(messages, **llm_kwargs)
+                    response_text += "</think>" + response.text()
+                    action = response_text.strip()
+                    reasoning_end = action.find("</think>") + len("</think>")
             else:
                 reasoning_end += len("</think>")
 
-            # Extract the reasoning part from the response.
             thinking = action[:reasoning_end].strip()
-            # Extract the action part from the response.
             action = action[reasoning_end:].strip()
 
         elif self.llm in CLAUDE_MODELS:

--- a/agents/reasoning.py
+++ b/agents/reasoning.py
@@ -90,7 +90,11 @@ class ReasoningAgent(tales.Agent):
 
         self.act_temp = kwargs["act_temp"]
         self.cot_temp = kwargs["cot_temp"]
-        self.reasoning_effort = kwargs["reasoning_effort"]
+        reasoning_effort = kwargs["reasoning_effort"]
+        # --reasoning-effort may be a numeric string (e.g., "1024"); convert to int.
+        if isinstance(reasoning_effort, str) and reasoning_effort.isdigit():
+            reasoning_effort = int(reasoning_effort)
+        self.reasoning_effort = reasoning_effort
         self.conversation = kwargs["conversation"]
 
     @property
@@ -124,13 +128,32 @@ class ReasoningAgent(tales.Agent):
         stop=stop_after_attempt(100),
     )
     def _llm_call_from_conversation(self, conversation, *args, **kwargs):
-        for i in range(10):
-            response = conversation.prompt(*args, **kwargs)
-            response.duration_ms()  # Forces the response to be computed.
-            if response.text():
-                return response  # Non-empty response, otherwise retry.
+        extra_body = kwargs.pop("extra_body", None)
+        if extra_body:
+            # Monkey-patch model.build_kwargs to inject extra_body into API call
+            original_build_kwargs = self.model.__class__.build_kwargs
 
-        return ""
+            def patched_build_kwargs(self_model, prompt, stream):
+                result = original_build_kwargs(self_model, prompt, stream)
+                result["extra_body"] = extra_body
+                return result
+
+            self.model.__class__.build_kwargs = patched_build_kwargs
+
+        try:
+            for i in range(10):
+                response = conversation.prompt(*args, **kwargs)
+                response.duration_ms()  # Forces the response to be computed.
+                if response.text():
+                    return response  # Non-empty response, otherwise retry.
+                # Remove the failed empty response from conversation to prevent accumulation
+                if conversation.responses:
+                    conversation.responses.pop()
+        finally:
+            if extra_body:
+                self.model.__class__.build_kwargs = original_build_kwargs
+
+        return response  # Return last response even if empty
 
     def _llm_call_from_messages(self, messages, *args, **kwargs):
         conversation = messages2conversation(self.model, messages)
@@ -195,9 +218,13 @@ class ReasoningAgent(tales.Agent):
                         "content": response_text.strip() + "</think>",
                     }
                 )
-                llm_kwargs["max_tokens"] = (
-                    100  # Text actions should be short phrases but deepseek forces thought process by starting the generation with <think>.
+                messages.append(
+                    {
+                        "role": "user",
+                        "content": "> ",
+                    }
                 )
+                llm_kwargs["max_tokens"] = 100  # Text actions should be short phrases.
                 llm_kwargs["temperature"] = self.act_temp
                 llm_kwargs["extra_body"] = {
                     "chat_template_kwargs": {"enable_thinking": False}
@@ -214,7 +241,7 @@ class ReasoningAgent(tales.Agent):
             # Extract the action part from the response.
             action = action[reasoning_end:].strip()
 
-        if "DeepSeek-R1" in self.llm:
+        if "DeepSeek-R1" in self.llm or "DeepSeek-V4" in self.llm:
             # Strip the reasoning <think> and </think>.
             reasoning_end = action.find("</think>")
             if reasoning_end == -1:

--- a/agents/walkthrough.py
+++ b/agents/walkthrough.py
@@ -5,46 +5,33 @@ from tales.agent import register
 from tales.token import get_token_counter
 
 
-class WalkthroughExhausted(Exception):
-    """Raised when the walkthrough has no more actions but the game isn't won."""
-
-    pass
-
-
 class WalkthroughAgent(tales.Agent):
     def __init__(self, **kwargs):
         self.token_counter = get_token_counter()
-        self.walkthrough = []
+        self.walkthrough = None
 
     @property
     def uid(self):
-        return "WalkthroughAgent"
+        return f"WalkthroughAgent"
 
     @property
     def params(self):
         return {}
 
     def reset(self, obs, info, env_name):
-        raw = info.get("extra.walkthrough")
-        if raw is None:
-            raise ValueError(f"{env_name} does not provide 'extra.walkthrough' in info")
-        # Store in reverse order so we can pop from the end.
-        self.walkthrough = list(raw)[::-1]
+        # Store the walkthrough in reverse order so we can pop from it.
+        if self.walkthrough is None:
+            self.walkthrough = info.get("extra.walkthrough")[::-1]
 
     def act(self, obs, reward, done, info):
         stats = {
             "prompt": None,
             "response": None,
             "nb_tokens": self.token_counter(text=obs),
-            "nb_tokens_prompt": self.token_counter(text=obs),
-            "nb_tokens_response": 0,
-            "nb_tokens_thinking": 0,
         }
 
         if len(self.walkthrough) == 0:
-            raise WalkthroughExhausted(
-                "Walkthrough actions exhausted before the game was won."
-            )
+            return "QUIT", stats
 
         return self.walkthrough.pop(), stats
 

--- a/benchmark.py
+++ b/benchmark.py
@@ -19,7 +19,13 @@ from tqdm import tqdm
 import tales
 from tales.logger import log, setup_logging
 from tales.utils import NumpyEncoder
-from tales.wandb_utils import WANDB_PROJECT, fetch_run_trajectory, find_matching_run
+from tales.wandb_utils import (
+    WANDB_ENTITY,
+    WANDB_PROJECT,
+    _wandb_path,
+    fetch_run_trajectory,
+    find_matching_run,
+)
 
 os.environ["WANDB_MODE"] = "disabled"
 
@@ -244,6 +250,9 @@ def play_with_agent(
         action, stats = agent.act(
             state["obs"], state["score"], state["done"], state["info"]
         )
+        thinking = stats.get("thinking")
+        if thinking:
+            log.debug(colored(f"💭 {thinking}", "cyan"))
         log.debug(colored(f"> {action}", "green"))
 
         if args.debug:
@@ -358,31 +367,40 @@ def evaluate(agent, env_name, args):
     if args.wandb and not args.force_all:
         # Check if there already exists a run with the same name using Wandb API.
         wandb_api = wandb.Api()
-        wandb_runs = wandb_api.runs(filters={"display_name": run_name})
+        wandb_runs = wandb_api.runs(_wandb_path(), filters={"display_name": run_name})
         if wandb_runs:
             wandb_run = wandb_runs[0]
             log.info(f"Previous evaluation found: {wandb_run.url} ({wandb_run.state})")
             if wandb_run.state in ("finished", "running"):
-                log.info(colored("Skipped, already exists.", "yellow"))
-                log.removeHandler(fh)
-                summary = {
-                    "status": wandb_run.state,
-                    "env_name": env_name,
-                    "env_params": env_params,
-                    "wandb_run_id": wandb_run.id,
-                    "wandb_url": wandb_run.url,
-                    "nb_steps": wandb_run.summary["total/Env. Steps"],
-                    "nb_moves": wandb_run.summary["total/Game Moves"],
-                    "nb_invalid_actions": wandb_run.summary["total/Invalid Actions"],
-                    "nb_losts": wandb_run.summary["total/Losts"],
-                    "nb_wins": wandb_run.summary["total/Wins"],
-                    "nb_resets": wandb_run.summary["total/Resets"],
-                    "highscore": wandb_run.summary["final/Highscore"],
-                    "max_score": wandb_run.summary["final/Game Max Score"],
-                    "norm_score": wandb_run.summary["final/Normalized Score"],
-                    "duration": wandb_run.summary["final/Duration"],
-                }
-                return summary
+                if "total/Env. Steps" not in wandb_run.summary:
+                    log.info(
+                        colored(
+                            "Previous run has no summary data, re-running.", "yellow"
+                        )
+                    )
+                else:
+                    log.info(colored("Skipped, already exists.", "yellow"))
+                    log.removeHandler(fh)
+                    summary = {
+                        "status": wandb_run.state,
+                        "env_name": env_name,
+                        "env_params": env_params,
+                        "wandb_run_id": wandb_run.id,
+                        "wandb_url": wandb_run.url,
+                        "nb_steps": wandb_run.summary["total/Env. Steps"],
+                        "nb_moves": wandb_run.summary["total/Game Moves"],
+                        "nb_invalid_actions": wandb_run.summary[
+                            "total/Invalid Actions"
+                        ],
+                        "nb_losts": wandb_run.summary["total/Losts"],
+                        "nb_wins": wandb_run.summary["total/Wins"],
+                        "nb_resets": wandb_run.summary["total/Resets"],
+                        "highscore": wandb_run.summary["final/Highscore"],
+                        "max_score": wandb_run.summary["final/Game Max Score"],
+                        "norm_score": wandb_run.summary["final/Normalized Score"],
+                        "duration": wandb_run.summary["final/Duration"],
+                    }
+                    return summary
 
     # initialize wandb
     wandb_config = {
@@ -401,6 +419,7 @@ def evaluate(agent, env_name, args):
         wandb_config["replay_steps"] = len(trajectory_df)
     wandb_run = wandb.init(
         project=WANDB_PROJECT,
+        entity=WANDB_ENTITY,
         config=wandb_config,
         reinit=True,
         name=run_name,

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,32 @@
+FROM vllm/vllm-openai:latest
+
+USER root
+
+# System dependencies (Java needed for ScienceWorld and TextWorldExpress)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    default-jre-headless \
+    build-essential \
+    git \
+    curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /usr/bin/python3 /usr/bin/python
+
+WORKDIR /app
+
+# Install Python dependencies first (for layer caching)
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Install the project
+COPY . .
+RUN pip install --no-cache-dir -e .
+
+# Validate all frameworks load
+RUN python -c "import tales; print(f'Loaded {len(tales.tasks)} tasks, {len(tales.envs)} envs'); assert len(tales.envs) > 0"
+
+# Download game data at build time
+RUN python -m tales.download
+
+# Entrypoint handles: start vLLM, wait, run benchmark
+RUN chmod +x /app/docker/entrypoint.sh
+ENTRYPOINT ["/app/docker/entrypoint.sh"]

--- a/docker/Dockerfile.sglang
+++ b/docker/Dockerfile.sglang
@@ -1,0 +1,31 @@
+FROM lmsysorg/sglang:latest
+
+USER root
+
+# System dependencies (Java needed for ScienceWorld and TextWorldExpress)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    default-jre-headless \
+    build-essential \
+    git \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install Python dependencies first (for layer caching)
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Install the project
+COPY . .
+RUN pip install --no-cache-dir -e .
+
+# Validate all frameworks load
+RUN python -c "import tales; print(f'Loaded {len(tales.tasks)} tasks, {len(tales.envs)} envs'); assert len(tales.envs) > 0"
+
+# Download game data at build time
+RUN python -m tales.download
+
+# Entrypoint handles: start server (vLLM or SGLang), wait, run benchmark
+RUN chmod +x /app/docker/entrypoint.sh
+ENTRYPOINT ["/app/docker/entrypoint.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,182 @@
+# Docker Infrastructure
+
+All-in-one images that bundle an inference server (vLLM or SGLang) with the TALES benchmark suite. The entrypoint starts the server, waits for readiness, and runs the benchmark — no external orchestration needed.
+
+## Quick Start
+
+```bash
+# Build (from repo root)
+docker build -f docker/Dockerfile -t tales .
+
+# Run a benchmark with a local model
+docker run --gpus all \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  -e MODEL_NAME=Qwen/Qwen3-4B \
+  -e ENVS="jericho" \
+  -e WANDB_API_KEY=$WANDB_API_KEY \
+  -e WANDB=true \
+  tales
+```
+
+Or use the helper script (see `run_experiment.sh` in the repo root).
+
+## Images
+
+| Image | Base | Use when |
+|-------|------|----------|
+| `docker/Dockerfile` | `vllm/vllm-openai:latest` | Default. Works with most models. |
+| `docker/Dockerfile.sglang` | `lmsysorg/sglang:latest` | Model is incompatible with vLLM (e.g., MiniMax-M2.7 FP8). |
+
+Build the SGLang variant:
+
+```bash
+docker build -f docker/Dockerfile.sglang -t tales-sglang .
+```
+
+## Files
+
+- `Dockerfile` — vLLM-based all-in-one image
+- `Dockerfile.sglang` — SGLang-based all-in-one image
+- `entrypoint.sh` — Unified entrypoint: starts server, waits, runs benchmark
+
+## Environment Variables
+
+### Server Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MODEL_NAME` | *(required)* | HuggingFace model ID (e.g., `Qwen/Qwen3-30B-A3B`) |
+| `SERVER_TYPE` | `vllm` | Inference backend: `vllm` or `sglang` |
+| `SERVER_PORT` | `8000` | Port for the inference server |
+| `SERVER_URL` | *(auto)* | Set to skip local server startup and use an external endpoint |
+| `SERVER_ARGS` | | Extra CLI args passed to the server |
+| `SERVER_WAIT_TIMEOUT` | `600` | Abort if server produces no log output for this many seconds |
+| `GPU_COUNT` | `1` | Number of GPUs (sets tensor parallelism) |
+| `DP_SIZE` | | Data parallel size (TP = GPU_COUNT / DP_SIZE) |
+| `MAX_MODEL_LEN` | | Max context length (vLLM: `--max-model-len`, SGLang: `--context-length`) |
+
+### vLLM-Specific
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `REASONING_PARSER` | | Reasoning parser for vLLM (e.g., `deepseek_r1`) |
+| `VLLM_MOE_BACKEND` | | MoE backend override (`triton`, `auto`, etc.) |
+
+### Benchmark Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AGENT_TYPE` | `zero-shot` | Agent type: `zero-shot` or `reasoning` |
+| `AGENT_FILE` | *(auto)* | Agent script path (auto-detected from AGENT_TYPE) |
+| `NB_STEPS` | `100` | Max steps per game |
+| `CONTEXT_LIMIT` | `100` | Context window limit |
+| `ENVS` | *(all)* | Space-separated env/task names |
+| `N_SEEDS` | `5` | Number of seeds to run |
+| `SEED_PREFIX` | `20241106` | Seed prefix (seeds = prefix+1, prefix+2, ...) |
+| `PARALLEL` | `0` | Concurrency: 0=all seeds at once, 1=sequential, N=cap |
+| `WANDB` | `false` | Enable WandB logging (`true`/`false`) |
+| `CONTINUE_FROM` | | WandB run ID to resume from (or `auto`) |
+| `FORCE_FAILED` | `false` | Re-run only failed experiments |
+| `REASONING_EFFORT` | | Max thinking tokens for reasoning agent |
+| `CONVERSATION` | `true` | Use conversation mode |
+| `EXTRA_ARGS` | | Additional args appended to the benchmark command |
+
+### Secrets (via env or mounted files)
+
+| Variable | Description |
+|----------|-------------|
+| `WANDB_API_KEY` | WandB API key (required if `WANDB=true`) |
+| `HF_TOKEN` | HuggingFace token (for gated models) |
+
+### Debugging
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PAUSE_ON_FAILURE` | `600` | Seconds to keep container alive after failure (for log inspection) |
+
+## Usage Examples
+
+### Run with vLLM (default)
+
+```bash
+docker run --gpus all \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  -e MODEL_NAME=Qwen/Qwen3-30B-A3B \
+  -e GPU_COUNT=4 \
+  -e ENVS="JerichoEnvZork1 JerichoEnvZork3" \
+  -e N_SEEDS=3 \
+  -e WANDB=true \
+  -e WANDB_API_KEY=$WANDB_API_KEY \
+  -e HF_TOKEN=$HF_TOKEN \
+  tales
+```
+
+### Run with SGLang
+
+```bash
+docker run --gpus all \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  -e MODEL_NAME=MiniMaxAI/MiniMax-M2.7 \
+  -e SERVER_TYPE=sglang \
+  -e GPU_COUNT=8 \
+  -e DP_SIZE=2 \
+  -e ENVS="jericho" \
+  -e WANDB=true \
+  -e WANDB_API_KEY=$WANDB_API_KEY \
+  tales-sglang
+```
+
+### Reasoning agent with thinking budget
+
+```bash
+docker run --gpus all \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  -e MODEL_NAME=Qwen/Qwen3-30B-A3B \
+  -e AGENT_TYPE=reasoning \
+  -e REASONING_EFFORT=1024 \
+  -e GPU_COUNT=4 \
+  -e ENVS="jericho" \
+  tales
+```
+
+### Use an external server
+
+```bash
+# Point to an already-running vLLM/SGLang instance
+docker run \
+  -e MODEL_NAME=Qwen/Qwen3-30B-A3B \
+  -e SERVER_URL=http://host.docker.internal:8000/v1 \
+  -e ENVS="JerichoEnvZork1" \
+  tales
+```
+
+### Pass custom args directly
+
+```bash
+# Override entrypoint env-var logic entirely
+docker run --gpus all \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  -e MODEL_NAME=Qwen/Qwen3-4B \
+  tales \
+  --agent agents/llm.py zero-shot --llm Qwen/Qwen3-4B --nb-steps 50 --envs JerichoEnvZork1 --seed 1
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────┐
+│  Container                              │
+│                                         │
+│  entrypoint.sh                          │
+│    │                                    │
+│    ├─ Start server (vLLM or SGLang)     │
+│    │    └─ Background process           │
+│    │                                    │
+│    ├─ Wait for /v1/models endpoint      │
+│    │    └─ Activity-based timeout       │
+│    │                                    │
+│    └─ Run benchmark.py (N seeds × envs) │
+│         └─ Parallel work units          │
+│                                         │
+└─────────────────────────────────────────┘
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -50,6 +50,7 @@ docker build -f docker/Dockerfile.sglang -t tales-sglang .
 | `SERVER_PORT` | `8000` | Port for the inference server |
 | `SERVER_URL` | *(auto)* | Set to skip local server startup and use an external endpoint |
 | `SERVER_ARGS` | | Extra CLI args passed to the server |
+| `CHAT_TEMPLATE` | *(auto)* | Path to Jinja2 chat template file. Auto-detected for DeepSeek-V4 |
 | `SERVER_WAIT_TIMEOUT` | `600` | Abort if server produces no log output for this many seconds |
 | `GPU_COUNT` | `1` | Number of GPUs (sets tensor parallelism) |
 | `DP_SIZE` | | Data parallel size (TP = GPU_COUNT / DP_SIZE) |

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,379 @@
+#!/bin/bash
+set -e
+
+# Sleep before exiting on failure so logs can be inspected
+PAUSE_ON_FAILURE="${PAUSE_ON_FAILURE:-600}"
+trap 'EXIT_CODE=$?; if [ $EXIT_CODE -ne 0 ]; then echo "=== FAILED (exit $EXIT_CODE). Pod will stay for ${PAUSE_ON_FAILURE}s for log inspection ==="; sleep $PAUSE_ON_FAILURE; fi' EXIT
+
+# --- Persist logs to PVC (survives pod deletion / preemption) ---
+if [ -d "/data" ] && [ -n "$MODEL_NAME" ]; then
+    LOG_DIR="/data/tales-logs"
+    mkdir -p "$LOG_DIR"
+    TIMESTAMP=$(date +%Y%m%dT%H%M%S)
+    MODEL_SLUG=$(echo "${MODEL_NAME}" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+    LOG_FILE="${LOG_DIR}/${MODEL_SLUG}-${TIMESTAMP}.log"
+    echo "Logging to ${LOG_FILE}"
+    exec > >(tee -a "$LOG_FILE") 2>&1
+fi
+
+# --- Server type: vllm (default) or sglang ---
+SERVER_TYPE="${SERVER_TYPE:-vllm}"
+# Neutral naming with legacy fallbacks
+SERVER_PORT="${SERVER_PORT:-${VLLM_PORT:-8000}}"
+SERVER_URL="${SERVER_URL:-${VLLM_URL:-}}"
+SERVER_ARGS="${SERVER_ARGS:-${VLLM_ARGS:-}}"
+
+# --- Start inference server (if MODEL_NAME is set and SERVER_URL is not) ---
+if [ -n "$MODEL_NAME" ] && [ -z "$SERVER_URL" ]; then
+    SERVER_LOG="/tmp/server.log"
+
+    if [ "$SERVER_TYPE" = "sglang" ]; then
+        # ===================== SGLang =====================
+        echo "Starting SGLang server for ${MODEL_NAME} on port ${SERVER_PORT}..."
+        SGLANG_EXTRA_ARGS="--trust-remote-code"
+
+        # GPU parallelism (SGLang DP requires router mode — only TP supported here)
+        if [ -n "$GPU_COUNT" ] && [ "$GPU_COUNT" -gt 1 ] 2>/dev/null; then
+            if [ -n "$DP_SIZE" ] && [ "$DP_SIZE" -gt 1 ] 2>/dev/null; then
+                TP_SIZE=$((GPU_COUNT / DP_SIZE))
+                SGLANG_EXTRA_ARGS="${SGLANG_EXTRA_ARGS} --tp ${TP_SIZE} --dp ${DP_SIZE}"
+            else
+                SGLANG_EXTRA_ARGS="${SGLANG_EXTRA_ARGS} --tp ${GPU_COUNT}"
+            fi
+        fi
+
+        if [ -n "$MAX_MODEL_LEN" ]; then
+            SGLANG_EXTRA_ARGS="${SGLANG_EXTRA_ARGS} --context-length ${MAX_MODEL_LEN}"
+        fi
+
+        if [ -n "$SERVER_ARGS" ]; then
+            SGLANG_EXTRA_ARGS="${SGLANG_EXTRA_ARGS} ${SERVER_ARGS}"
+        fi
+
+        if [ -n "$LOG_DIR" ]; then
+            SERVER_LOG_PERSIST="${LOG_DIR}/${MODEL_SLUG}-${TIMESTAMP}-sglang.log"
+            python -m sglang.launch_server \
+                --model-path "${MODEL_NAME}" \
+                --served-model-name "${MODEL_NAME}" \
+                --port "${SERVER_PORT}" \
+                --host 0.0.0.0 \
+                ${SGLANG_EXTRA_ARGS} \
+                > >(tee "$SERVER_LOG" >> "$SERVER_LOG_PERSIST") 2>&1 &
+        else
+            python -m sglang.launch_server \
+                --model-path "${MODEL_NAME}" \
+                --served-model-name "${MODEL_NAME}" \
+                --port "${SERVER_PORT}" \
+                --host 0.0.0.0 \
+                ${SGLANG_EXTRA_ARGS} \
+                > "$SERVER_LOG" 2>&1 &
+        fi
+
+    else
+        # ===================== vLLM (default) =====================
+        echo "Starting vLLM server for ${MODEL_NAME} on port ${SERVER_PORT}..."
+        VLLM_EXTRA_ARGS="${VLLM_EXTRA_ARGS:---trust-remote-code}"
+        if [ -n "$REASONING_PARSER" ] && [ "$AGENT_TYPE" != "reasoning" ]; then
+            # Skip reasoning parser when using reasoning agent — it handles <think> tags itself
+            VLLM_EXTRA_ARGS="${VLLM_EXTRA_ARGS} --reasoning-parser ${REASONING_PARSER}"
+        fi
+        if [ "$AGENT_TYPE" = "reasoning" ]; then
+            # Reasoning agent may send custom chat templates to control thinking mode
+            VLLM_EXTRA_ARGS="${VLLM_EXTRA_ARGS} --trust-request-chat-template"
+        fi
+        if [ -n "$GPU_COUNT" ] && [ "$GPU_COUNT" -gt 1 ] 2>/dev/null; then
+            TP_SIZE="${GPU_COUNT}"
+            if [ -n "$DP_SIZE" ] && [ "$DP_SIZE" -gt 1 ] 2>/dev/null; then
+                TP_SIZE=$((GPU_COUNT / DP_SIZE))
+                VLLM_EXTRA_ARGS="${VLLM_EXTRA_ARGS} --data-parallel-size ${DP_SIZE}"
+            fi
+            VLLM_EXTRA_ARGS="${VLLM_EXTRA_ARGS} --tensor-parallel-size ${TP_SIZE}"
+        fi
+        if [ -n "$VLLM_MOE_BACKEND" ]; then
+            VLLM_EXTRA_ARGS="${VLLM_EXTRA_ARGS} --moe-backend ${VLLM_MOE_BACKEND}"
+        fi
+        if [ -n "$SERVER_ARGS" ]; then
+            VLLM_EXTRA_ARGS="${VLLM_EXTRA_ARGS} ${SERVER_ARGS}"
+        fi
+        ROPE_SCALING_ARGS=""
+        if [ -n "$MAX_MODEL_LEN" ]; then
+            VLLM_EXTRA_ARGS="${VLLM_EXTRA_ARGS} --max-model-len ${MAX_MODEL_LEN}"
+            ROPE_SCALING_ARGS='--rope-scaling {"rope_type":"yarn","factor":4.0,"original_max_position_embeddings":32768}'
+        fi
+        if [ -n "$LOG_DIR" ]; then
+            SERVER_LOG_PERSIST="${LOG_DIR}/${MODEL_SLUG}-${TIMESTAMP}-vllm.log"
+            python -m vllm.entrypoints.openai.api_server \
+                --model "${MODEL_NAME}" \
+                --served-model-name "${MODEL_NAME}" \
+                --port "${SERVER_PORT}" \
+                --host 0.0.0.0 \
+                ${VLLM_EXTRA_ARGS} ${ROPE_SCALING_ARGS} \
+                > >(tee "$SERVER_LOG" >> "$SERVER_LOG_PERSIST") 2>&1 &
+        else
+            python -m vllm.entrypoints.openai.api_server \
+                --model "${MODEL_NAME}" \
+                --served-model-name "${MODEL_NAME}" \
+                --port "${SERVER_PORT}" \
+                --host 0.0.0.0 \
+                ${VLLM_EXTRA_ARGS} ${ROPE_SCALING_ARGS} \
+                > "$SERVER_LOG" 2>&1 &
+        fi
+    fi
+
+    SERVER_PID=$!
+    SERVER_URL="http://localhost:${SERVER_PORT}/v1"
+fi
+
+# --- Configure LLM model endpoint ---
+if [ -n "$SERVER_URL" ] && [ -n "$MODEL_NAME" ]; then
+    CONFIG_DIR="${HOME}/.config/io.datasette.llm"
+    mkdir -p "$CONFIG_DIR"
+    cat > "$CONFIG_DIR/extra-openai-models.yaml" << EOF
+- model_id: ${MODEL_NAME}
+  model_name: ${MODEL_NAME}
+  api_base: "${SERVER_URL}"
+EOF
+    echo "Configured llm to use ${MODEL_NAME} at ${SERVER_URL}"
+fi
+
+# --- Wait for server readiness ---
+if [ -n "$SERVER_URL" ]; then
+    echo "Waiting for ${SERVER_TYPE} server at ${SERVER_URL}..."
+    INACTIVITY_TIMEOUT=${SERVER_WAIT_TIMEOUT:-${VLLM_WAIT_TIMEOUT:-600}}
+    elapsed=0
+    last_activity=$(date +%s)
+    # Stream server logs during startup so user can see progress
+    tail -f "$SERVER_LOG" 2>/dev/null &
+    TAIL_PID=$!
+    until curl -sf "${SERVER_URL}/models" > /dev/null 2>&1; do
+        # Check if server process is still alive
+        if ! kill -0 $SERVER_PID 2>/dev/null; then
+            kill $TAIL_PID 2>/dev/null || true
+            echo "ERROR: ${SERVER_TYPE} process died during startup."
+            tail -50 "$SERVER_LOG"
+            exit 1
+        fi
+        # Check for log activity (file modification time)
+        if [ -f "$SERVER_LOG" ]; then
+            log_mtime=$(stat -c %Y "$SERVER_LOG" 2>/dev/null || echo "$last_activity")
+            if [ "$log_mtime" -gt "$last_activity" ]; then
+                last_activity=$log_mtime
+            fi
+        fi
+        now=$(date +%s)
+        inactive_secs=$((now - last_activity))
+        if [ $inactive_secs -ge $INACTIVITY_TIMEOUT ]; then
+            kill $TAIL_PID 2>/dev/null || true
+            echo "ERROR: ${SERVER_TYPE} produced no output for ${INACTIVITY_TIMEOUT}s, aborting."
+            tail -50 "$SERVER_LOG"
+            exit 1
+        fi
+        sleep 5
+        elapsed=$((elapsed + 5))
+    done
+    # Stop streaming logs once server is ready
+    kill $TAIL_PID 2>/dev/null || true
+    wait $TAIL_PID 2>/dev/null || true
+    echo ""
+    echo "${SERVER_TYPE} server is ready (took ${elapsed}s)."
+fi
+
+# --- Run benchmark ---
+# If args are passed directly, use them; otherwise build from env vars.
+if [ $# -gt 0 ]; then
+    echo "Running: python benchmark.py $@"
+    exec python benchmark.py "$@"
+fi
+
+# Build command from env vars
+AGENT_TYPE="${AGENT_TYPE:-zero-shot}"
+# Auto-detect agent file from type if not explicitly set
+if [ -z "$AGENT_FILE" ]; then
+    case "$AGENT_TYPE" in
+        reasoning) AGENT_FILE="agents/reasoning.py" ;;
+        *) AGENT_FILE="agents/llm.py" ;;
+    esac
+fi
+NB_STEPS="${NB_STEPS:-100}"
+CONTEXT_LIMIT="${CONTEXT_LIMIT:-100}"
+SEED_PREFIX="${SEED_PREFIX:-20241106}"
+N_SEEDS="${N_SEEDS:-5}"
+
+# Base command (without seed or --envs - added per work unit)
+BASE_CMD="python benchmark.py --agent ${AGENT_FILE} ${AGENT_TYPE}"
+BASE_CMD="${BASE_CMD} --llm ${MODEL_NAME}"
+BASE_CMD="${BASE_CMD} --nb-steps ${NB_STEPS}"
+BASE_CMD="${BASE_CMD} --context ${CONTEXT_LIMIT}"
+
+# Conversation mode (default: on)
+if [ "${CONVERSATION}" != "false" ]; then
+    BASE_CMD="${BASE_CMD} --conversation"
+fi
+
+# Wandb logging (default: off)
+if [ "${WANDB}" = "true" ]; then
+    BASE_CMD="${BASE_CMD} --wandb"
+fi
+
+# Optional flags
+if [ "${FORCE_ALL}" = "true" ]; then
+    BASE_CMD="${BASE_CMD} --force-all"
+fi
+
+if [ "${FORCE_FAILED}" = "true" ]; then
+    BASE_CMD="${BASE_CMD} --force-failed"
+fi
+
+if [ -n "$CONTINUE_FROM" ]; then
+    BASE_CMD="${BASE_CMD} --continue-from ${CONTINUE_FROM}"
+fi
+
+if [ "${ADMISSIBLE_COMMANDS}" = "true" ]; then
+    BASE_CMD="${BASE_CMD} --admissible-commands"
+fi
+
+if [ -n "$REASONING_EFFORT" ]; then
+    BASE_CMD="${BASE_CMD} --reasoning-effort ${REASONING_EFFORT}"
+fi
+
+if [ -n "$EXTRA_ARGS" ]; then
+    BASE_CMD="${BASE_CMD} ${EXTRA_ARGS}"
+fi
+
+# --- Parallelism ---
+# PARALLEL=0 (default): run all seeds concurrently, each with full env list.
+# PARALLEL=1: fully sequential (legacy behavior).
+# PARALLEL=N: cap at N concurrent processes; if N > N_SEEDS, split envs into chunks too.
+PARALLEL="${PARALLEL:-0}"
+
+# Resolve the full environment list (needed for splitting when PARALLEL > N_SEEDS).
+resolve_envs() {
+    if [ -z "$ENVS" ]; then
+        python -c "import tales; print(' '.join(tales.envs))"
+    else
+        # Expand task names (e.g., "jericho") into individual envs
+        python -c "
+import tales
+envs = [e for t in '''$ENVS'''.split() for e in (tales.envs_per_task[t] if t in tales.tasks else [t])]
+print(' '.join(envs))
+"
+    fi
+}
+
+# Split a space-separated list into N chunks, printing chunk at index K (0-based).
+get_chunk() {
+    local items="$1"
+    local n_chunks="$2"
+    local chunk_idx="$3"
+    python -c "
+items = '''$items'''.split()
+n = int('$n_chunks')
+k = int('$chunk_idx')
+chunk_size = len(items) // n
+remainder = len(items) % n
+start = k * chunk_size + min(k, remainder)
+end = start + chunk_size + (1 if k < remainder else 0)
+print(' '.join(items[start:end]))
+"
+}
+
+run_work_unit() {
+    local seed="$1"
+    local envs_subset="$2"
+    local label="$3"
+    local cmd="${BASE_CMD} --seed ${seed}"
+    if [ -n "$envs_subset" ]; then
+        cmd="${cmd} --envs ${envs_subset}"
+    fi
+    echo "[${label}] Running: ${cmd}"
+    ${cmd}
+    local rc=$?
+    if [ $rc -ne 0 ]; then
+        echo "[${label}] FAILED (exit code $rc)"
+    else
+        echo "[${label}] Done."
+    fi
+    return $rc
+}
+
+# Determine effective concurrency
+if [ "$PARALLEL" -eq 0 ] 2>/dev/null; then
+    EFFECTIVE_PARALLEL=$N_SEEDS
+elif [ "$PARALLEL" -eq 1 ] 2>/dev/null; then
+    EFFECTIVE_PARALLEL=1
+else
+    EFFECTIVE_PARALLEL=$PARALLEL
+fi
+
+# Calculate env splits per seed
+if [ "$EFFECTIVE_PARALLEL" -gt "$N_SEEDS" ]; then
+    GAMES_PER_SEED=$(( (EFFECTIVE_PARALLEL + N_SEEDS - 1) / N_SEEDS ))
+else
+    GAMES_PER_SEED=1
+fi
+
+echo "Parallelism: PARALLEL=${PARALLEL} (effective=${EFFECTIVE_PARALLEL}, seeds=${N_SEEDS}, env_splits_per_seed=${GAMES_PER_SEED})"
+
+# Resolve envs if we need to split them
+if [ "$GAMES_PER_SEED" -gt 1 ]; then
+    RESOLVED_ENVS=$(resolve_envs)
+    echo "Resolved ${#RESOLVED_ENVS[@]} environments for splitting into ${GAMES_PER_SEED} chunks per seed."
+fi
+
+# --- Execute work units ---
+RUNNING=0
+FAILURES=0
+TOTAL_UNITS=0
+
+for i in $(seq 1 ${N_SEEDS}); do
+    SEED="${SEED_PREFIX}${i}"
+
+    if [ "$GAMES_PER_SEED" -gt 1 ]; then
+        for chunk_idx in $(seq 0 $((GAMES_PER_SEED - 1))); do
+            CHUNK=$(get_chunk "$RESOLVED_ENVS" "$GAMES_PER_SEED" "$chunk_idx")
+            [ -z "$CHUNK" ] && continue
+            TOTAL_UNITS=$((TOTAL_UNITS + 1))
+            LABEL="seed${i}/chunk$((chunk_idx+1))"
+
+            if [ "$EFFECTIVE_PARALLEL" -le 1 ]; then
+                run_work_unit "$SEED" "$CHUNK" "$LABEL" || FAILURES=$((FAILURES + 1))
+            else
+                run_work_unit "$SEED" "$CHUNK" "$LABEL" &
+                RUNNING=$((RUNNING + 1))
+                if [ "$RUNNING" -ge "$EFFECTIVE_PARALLEL" ]; then
+                    wait -n || FAILURES=$((FAILURES + 1))
+                    RUNNING=$((RUNNING - 1))
+                fi
+            fi
+        done
+    else
+        TOTAL_UNITS=$((TOTAL_UNITS + 1))
+        LABEL="seed${i}/${N_SEEDS}"
+        ENVS_ARG=""
+        [ -n "$ENVS" ] && ENVS_ARG="$ENVS"
+
+        if [ "$EFFECTIVE_PARALLEL" -le 1 ]; then
+            run_work_unit "$SEED" "$ENVS_ARG" "$LABEL" || FAILURES=$((FAILURES + 1))
+        else
+            run_work_unit "$SEED" "$ENVS_ARG" "$LABEL" &
+            RUNNING=$((RUNNING + 1))
+            if [ "$RUNNING" -ge "$EFFECTIVE_PARALLEL" ]; then
+                wait -n || FAILURES=$((FAILURES + 1))
+                RUNNING=$((RUNNING - 1))
+            fi
+        fi
+    fi
+done
+
+# Wait for remaining background jobs
+while [ "$RUNNING" -gt 0 ]; do
+    wait -n || FAILURES=$((FAILURES + 1))
+    RUNNING=$((RUNNING - 1))
+done
+
+if [ "$FAILURES" -gt 0 ]; then
+    echo "WARNING: ${FAILURES}/${TOTAL_UNITS} work units failed."
+    exit 1
+fi
+
+echo "All ${TOTAL_UNITS} work units completed successfully."

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -86,6 +86,24 @@ if [ -n "$MODEL_NAME" ] && [ -z "$SERVER_URL" ]; then
         # ===================== vLLM (default) =====================
         echo "Starting vLLM server for ${MODEL_NAME} on port ${SERVER_PORT}..."
         VLLM_EXTRA_ARGS="${VLLM_EXTRA_ARGS:---trust-remote-code}"
+        # --- Auto-detect reasoning parser for known model families ---
+        if [ -z "$REASONING_PARSER" ] && [ "$AGENT_TYPE" = "reasoning" ]; then
+            case "$MODEL_NAME" in
+                *DeepSeek-R1*|*deepseek-r1*) REASONING_PARSER="deepseek_r1" ;;
+                *DeepSeek-V3*|*DeepSeek-V4*|*deepseek-v3*|*deepseek-v4*) REASONING_PARSER="deepseek_v3" ;;
+                *Qwen3*|*qwen3*) REASONING_PARSER="qwen3" ;;
+                *gpt-oss*) REASONING_PARSER="openai_gptoss" ;;
+                *Magistral*|*Mistral-Small*|*Mistral-Large*) REASONING_PARSER="mistral" ;;
+                *MiniMax-M2*|*minimax-m2*) REASONING_PARSER="minimax_m2_append_think" ;;
+                *gemma-4*|*gemma4*) REASONING_PARSER="gemma4" ;;
+                # Nemotron: uses <think> text tags but Llama-3.3 tokenizer lacks
+                # special <think>/<think> token IDs — no vLLM parser works.
+                # Thinking is triggered via THINKING_INSTRUCTION in the prompt.
+            esac
+            if [ -n "$REASONING_PARSER" ]; then
+                echo "Auto-detected reasoning parser: ${REASONING_PARSER}"
+            fi
+        fi
         if [ -n "$REASONING_PARSER" ]; then
             # Enable vLLM's reasoning parser to separate thinking from content.
             # Always add it (even for reasoning agent) — Mistral-native models
@@ -139,6 +157,9 @@ if [ -n "$MODEL_NAME" ] && [ -z "$SERVER_URL" ]; then
     SERVER_PID=$!
     SERVER_URL="http://localhost:${SERVER_PORT}/v1"
 fi
+
+# Export vars so the Python benchmark process can detect vLLM mode
+export SERVER_URL SERVER_TYPE REASONING_PARSER
 
 # --- Configure LLM model endpoint ---
 if [ -n "$SERVER_URL" ] && [ -n "$MODEL_NAME" ]; then
@@ -194,6 +215,19 @@ if [ -n "$SERVER_URL" ]; then
     echo "${SERVER_TYPE} server is ready (took ${elapsed}s)."
 fi
 
+# --- Sanity check: verify thinking traces before full benchmark ---
+if [ -n "$SERVER_URL" ] && [ "$AGENT_TYPE" = "reasoning" ] && [ "${SKIP_SANITY_CHECK}" != "true" ]; then
+    echo ""
+    echo "Running thinking trace sanity check..."
+    if python scripts/sanity_check.py --model "${MODEL_NAME}" --server-url "${SERVER_URL}" --reasoning-parser "${REASONING_PARSER:-}"; then
+        echo "Sanity check passed, proceeding with benchmark."
+    else
+        echo "WARNING: Sanity check FAILED — model may not produce thinking traces."
+        echo "Set SKIP_SANITY_CHECK=true to bypass. Continuing anyway..."
+    fi
+    echo ""
+fi
+
 # --- Run benchmark ---
 # If args are passed directly, use them; otherwise build from env vars.
 if [ $# -gt 0 ]; then
@@ -202,7 +236,12 @@ if [ $# -gt 0 ]; then
 fi
 
 # Build command from env vars
+# Build command from env vars
 AGENT_TYPE="${AGENT_TYPE:-zero-shot}"
+# Auto-switch to reasoning agent when REASONING_EFFORT is set
+if [ -n "$REASONING_EFFORT" ] && [ "$AGENT_TYPE" = "zero-shot" ]; then
+    AGENT_TYPE="reasoning"
+fi
 # Auto-detect agent file from type if not explicitly set
 if [ -z "$AGENT_FILE" ]; then
     case "$AGENT_TYPE" in
@@ -250,6 +289,9 @@ fi
 
 if [ -n "$REASONING_EFFORT" ]; then
     BASE_CMD="${BASE_CMD} --reasoning-effort ${REASONING_EFFORT}"
+elif [ "$AGENT_TYPE" = "reasoning" ]; then
+    # Default thinking budget for reasoning agent when not explicitly set
+    BASE_CMD="${BASE_CMD} --cot-max-tokens 1024"
 fi
 
 if [ -n "$EXTRA_ARGS" ]; then

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -27,6 +27,15 @@ SERVER_ARGS="${SERVER_ARGS:-${VLLM_ARGS:-}}"
 if [ -n "$MODEL_NAME" ] && [ -z "$SERVER_URL" ]; then
     SERVER_LOG="/tmp/server.log"
 
+    # --- Auto-detect chat template for models that don't ship one ---
+    CHAT_TEMPLATE_ARG=""
+    if [ -n "$CHAT_TEMPLATE" ]; then
+        CHAT_TEMPLATE_ARG="--chat-template ${CHAT_TEMPLATE}"
+    elif echo "${MODEL_NAME}" | grep -qi "DeepSeek-V4"; then
+        CHAT_TEMPLATE_ARG="--chat-template /app/docker/templates/deepseek_v4.jinja2"
+        echo "Auto-detected DeepSeek-V4 model — using custom chat template"
+    fi
+
     if [ "$SERVER_TYPE" = "sglang" ]; then
         # ===================== SGLang =====================
         echo "Starting SGLang server for ${MODEL_NAME} on port ${SERVER_PORT}..."
@@ -48,6 +57,10 @@ if [ -n "$MODEL_NAME" ] && [ -z "$SERVER_URL" ]; then
 
         if [ -n "$SERVER_ARGS" ]; then
             SGLANG_EXTRA_ARGS="${SGLANG_EXTRA_ARGS} ${SERVER_ARGS}"
+        fi
+
+        if [ -n "$CHAT_TEMPLATE_ARG" ]; then
+            SGLANG_EXTRA_ARGS="${SGLANG_EXTRA_ARGS} ${CHAT_TEMPLATE_ARG}"
         fi
 
         if [ -n "$LOG_DIR" ]; then
@@ -94,6 +107,9 @@ if [ -n "$MODEL_NAME" ] && [ -z "$SERVER_URL" ]; then
         fi
         if [ -n "$SERVER_ARGS" ]; then
             VLLM_EXTRA_ARGS="${VLLM_EXTRA_ARGS} ${SERVER_ARGS}"
+        fi
+        if [ -n "$CHAT_TEMPLATE_ARG" ]; then
+            VLLM_EXTRA_ARGS="${VLLM_EXTRA_ARGS} ${CHAT_TEMPLATE_ARG}"
         fi
         ROPE_SCALING_ARGS=""
         if [ -n "$MAX_MODEL_LEN" ]; then

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -86,9 +86,11 @@ if [ -n "$MODEL_NAME" ] && [ -z "$SERVER_URL" ]; then
         # ===================== vLLM (default) =====================
         echo "Starting vLLM server for ${MODEL_NAME} on port ${SERVER_PORT}..."
         VLLM_EXTRA_ARGS="${VLLM_EXTRA_ARGS:---trust-remote-code}"
-        if [ -n "$REASONING_PARSER" ] && [ "$AGENT_TYPE" != "reasoning" ]; then
-            # Skip reasoning parser when using reasoning agent — it handles <think> tags itself
-            VLLM_EXTRA_ARGS="${VLLM_EXTRA_ARGS} --reasoning-parser ${REASONING_PARSER}"
+        if [ -n "$REASONING_PARSER" ]; then
+            # Enable vLLM's reasoning parser to separate thinking from content.
+            # Always add it (even for reasoning agent) — Mistral-native models
+            # require the parser for ANY thinking output.
+            VLLM_EXTRA_ARGS="${VLLM_EXTRA_ARGS} --reasoning-config {\"reasoning_parser\":\"${REASONING_PARSER}\"}"
         fi
         if [ "$AGENT_TYPE" = "reasoning" ]; then
             # Reasoning agent may send custom chat templates to control thinking mode

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -111,10 +111,8 @@ if [ -n "$MODEL_NAME" ] && [ -z "$SERVER_URL" ]; then
         if [ -n "$CHAT_TEMPLATE_ARG" ]; then
             VLLM_EXTRA_ARGS="${VLLM_EXTRA_ARGS} ${CHAT_TEMPLATE_ARG}"
         fi
-        ROPE_SCALING_ARGS=""
         if [ -n "$MAX_MODEL_LEN" ]; then
             VLLM_EXTRA_ARGS="${VLLM_EXTRA_ARGS} --max-model-len ${MAX_MODEL_LEN}"
-            ROPE_SCALING_ARGS='--rope-scaling {"rope_type":"yarn","factor":4.0,"original_max_position_embeddings":32768}'
         fi
         if [ -n "$LOG_DIR" ]; then
             SERVER_LOG_PERSIST="${LOG_DIR}/${MODEL_SLUG}-${TIMESTAMP}-vllm.log"
@@ -123,7 +121,7 @@ if [ -n "$MODEL_NAME" ] && [ -z "$SERVER_URL" ]; then
                 --served-model-name "${MODEL_NAME}" \
                 --port "${SERVER_PORT}" \
                 --host 0.0.0.0 \
-                ${VLLM_EXTRA_ARGS} ${ROPE_SCALING_ARGS} \
+                ${VLLM_EXTRA_ARGS} \
                 > >(tee "$SERVER_LOG" >> "$SERVER_LOG_PERSIST") 2>&1 &
         else
             python -m vllm.entrypoints.openai.api_server \
@@ -131,7 +129,7 @@ if [ -n "$MODEL_NAME" ] && [ -z "$SERVER_URL" ]; then
                 --served-model-name "${MODEL_NAME}" \
                 --port "${SERVER_PORT}" \
                 --host 0.0.0.0 \
-                ${VLLM_EXTRA_ARGS} ${ROPE_SCALING_ARGS} \
+                ${VLLM_EXTRA_ARGS} \
                 > "$SERVER_LOG" 2>&1 &
         fi
     fi
@@ -257,12 +255,12 @@ if [ -n "$EXTRA_ARGS" ]; then
 fi
 
 # --- Parallelism ---
-# PARALLEL=0 (default): run all seeds concurrently, each with full env list.
-# PARALLEL=1: fully sequential (legacy behavior).
-# PARALLEL=N: cap at N concurrent processes; if N > N_SEEDS, split envs into chunks too.
+# PARALLEL=0 or unset: fully sequential (one game at a time).
+# PARALLEL=N: run N games concurrently within each seed; seeds are always sequential.
+# Strategy: complete all games for seed 1, then seed 2, etc.
 PARALLEL="${PARALLEL:-0}"
 
-# Resolve the full environment list (needed for splitting when PARALLEL > N_SEEDS).
+# Resolve the full environment list.
 resolve_envs() {
     if [ -z "$ENVS" ]; then
         python -c "import tales; print(' '.join(tales.envs))"
@@ -312,79 +310,66 @@ run_work_unit() {
     return $rc
 }
 
-# Determine effective concurrency
-if [ "$PARALLEL" -eq 0 ] 2>/dev/null; then
-    EFFECTIVE_PARALLEL=$N_SEEDS
-elif [ "$PARALLEL" -eq 1 ] 2>/dev/null; then
+# Determine parallelism (within each seed)
+if [ "$PARALLEL" -le 1 ] 2>/dev/null; then
     EFFECTIVE_PARALLEL=1
 else
     EFFECTIVE_PARALLEL=$PARALLEL
 fi
 
-# Calculate env splits per seed
-if [ "$EFFECTIVE_PARALLEL" -gt "$N_SEEDS" ]; then
-    GAMES_PER_SEED=$(( (EFFECTIVE_PARALLEL + N_SEEDS - 1) / N_SEEDS ))
+# Resolve envs to split across parallel workers
+RESOLVED_ENVS=$(resolve_envs)
+N_ENVS=$(echo "$RESOLVED_ENVS" | wc -w)
+
+# Number of env chunks per seed = min(EFFECTIVE_PARALLEL, N_ENVS)
+if [ "$EFFECTIVE_PARALLEL" -gt "$N_ENVS" ]; then
+    N_CHUNKS=$N_ENVS
 else
-    GAMES_PER_SEED=1
+    N_CHUNKS=$EFFECTIVE_PARALLEL
 fi
 
-echo "Parallelism: PARALLEL=${PARALLEL} (effective=${EFFECTIVE_PARALLEL}, seeds=${N_SEEDS}, env_splits_per_seed=${GAMES_PER_SEED})"
+echo "Parallelism: PARALLEL=${EFFECTIVE_PARALLEL} workers per seed, seeds=${N_SEEDS} (sequential), envs=${N_ENVS}, chunks=${N_CHUNKS}"
 
-# Resolve envs if we need to split them
-if [ "$GAMES_PER_SEED" -gt 1 ]; then
-    RESOLVED_ENVS=$(resolve_envs)
-    echo "Resolved ${#RESOLVED_ENVS[@]} environments for splitting into ${GAMES_PER_SEED} chunks per seed."
-fi
-
-# --- Execute work units ---
-RUNNING=0
+# --- Execute work units: one seed at a time, parallel games within ---
 FAILURES=0
 TOTAL_UNITS=0
 
 for i in $(seq 1 ${N_SEEDS}); do
     SEED="${SEED_PREFIX}${i}"
+    echo "=== Starting seed ${i}/${N_SEEDS} (${SEED}) ==="
+    RUNNING=0
 
-    if [ "$GAMES_PER_SEED" -gt 1 ]; then
-        for chunk_idx in $(seq 0 $((GAMES_PER_SEED - 1))); do
-            CHUNK=$(get_chunk "$RESOLVED_ENVS" "$GAMES_PER_SEED" "$chunk_idx")
+    if [ "$N_CHUNKS" -le 1 ]; then
+        # Single worker: run all envs sequentially
+        TOTAL_UNITS=$((TOTAL_UNITS + 1))
+        LABEL="seed${i}"
+        ENVS_ARG=""
+        [ -n "$ENVS" ] && ENVS_ARG="$ENVS"
+        run_work_unit "$SEED" "$ENVS_ARG" "$LABEL" || FAILURES=$((FAILURES + 1))
+    else
+        # Multiple workers: split envs into chunks, run in parallel
+        for chunk_idx in $(seq 0 $((N_CHUNKS - 1))); do
+            CHUNK=$(get_chunk "$RESOLVED_ENVS" "$N_CHUNKS" "$chunk_idx")
             [ -z "$CHUNK" ] && continue
             TOTAL_UNITS=$((TOTAL_UNITS + 1))
             LABEL="seed${i}/chunk$((chunk_idx+1))"
 
-            if [ "$EFFECTIVE_PARALLEL" -le 1 ]; then
-                run_work_unit "$SEED" "$CHUNK" "$LABEL" || FAILURES=$((FAILURES + 1))
-            else
-                run_work_unit "$SEED" "$CHUNK" "$LABEL" &
-                RUNNING=$((RUNNING + 1))
-                if [ "$RUNNING" -ge "$EFFECTIVE_PARALLEL" ]; then
-                    wait -n || FAILURES=$((FAILURES + 1))
-                    RUNNING=$((RUNNING - 1))
-                fi
-            fi
-        done
-    else
-        TOTAL_UNITS=$((TOTAL_UNITS + 1))
-        LABEL="seed${i}/${N_SEEDS}"
-        ENVS_ARG=""
-        [ -n "$ENVS" ] && ENVS_ARG="$ENVS"
-
-        if [ "$EFFECTIVE_PARALLEL" -le 1 ]; then
-            run_work_unit "$SEED" "$ENVS_ARG" "$LABEL" || FAILURES=$((FAILURES + 1))
-        else
-            run_work_unit "$SEED" "$ENVS_ARG" "$LABEL" &
+            run_work_unit "$SEED" "$CHUNK" "$LABEL" &
             RUNNING=$((RUNNING + 1))
             if [ "$RUNNING" -ge "$EFFECTIVE_PARALLEL" ]; then
                 wait -n || FAILURES=$((FAILURES + 1))
                 RUNNING=$((RUNNING - 1))
             fi
-        fi
-    fi
-done
+        done
 
-# Wait for remaining background jobs
-while [ "$RUNNING" -gt 0 ]; do
-    wait -n || FAILURES=$((FAILURES + 1))
-    RUNNING=$((RUNNING - 1))
+        # Wait for all chunks of this seed to finish before next seed
+        while [ "$RUNNING" -gt 0 ]; do
+            wait -n || FAILURES=$((FAILURES + 1))
+            RUNNING=$((RUNNING - 1))
+        done
+    fi
+
+    echo "=== Seed ${i}/${N_SEEDS} complete ==="
 done
 
 if [ "$FAILURES" -gt 0 ]; then

--- a/docker/templates/deepseek_v4.jinja2
+++ b/docker/templates/deepseek_v4.jinja2
@@ -1,0 +1,25 @@
+{#- DeepSeek-V4 Chat Template for vLLM/SGLang.
+    Supports enable_thinking kwarg (default: true) to toggle thinking mode.
+    Based on the official encoding from https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro
+-#}
+{%- if not add_generation_prompt is defined %}{% set add_generation_prompt = false %}{% endif -%}
+{%- if enable_thinking is not defined %}{% set enable_thinking = true %}{% endif -%}
+{%- set ns = namespace(system_prompt='') -%}
+{%- for message in messages -%}
+  {%- if message['role'] == 'system' %}{% set ns.system_prompt = message['content'] %}{% endif -%}
+{%- endfor -%}
+{{ bos_token }}{{ ns.system_prompt }}
+{%- for message in messages -%}
+  {%- if message['role'] == 'user' -%}
+    {{ '<｜User｜>' + message['content'] }}
+  {%- elif message['role'] == 'assistant' -%}
+    {{ '<｜Assistant｜>' + (message['content'] or '') + '<｜end▁of▁sentence｜>' }}
+  {%- endif -%}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+  {%- if enable_thinking -%}
+    {{ '<｜Assistant｜><think>' }}
+  {%- else -%}
+    {{ '<｜Assistant｜></think>' }}
+  {%- endif -%}
+{%- endif -%}

--- a/run_experiment.sh
+++ b/run_experiment.sh
@@ -1,0 +1,267 @@
+#!/bin/bash
+# Run TALES benchmark experiment using local Docker.
+# Builds and runs the all-in-one container with the specified model and environments.
+#
+# Usage:
+#   ./run_experiment.sh --model Qwen/Qwen3-4B --envs JerichoEnvZork1 --gpu-count 1
+#   ./run_experiment.sh --model Qwen/Qwen3-30B-A3B --all --gpu-count 4 --wandb
+#   ./run_experiment.sh --model MiniMaxAI/MiniMax-M2.7 --server sglang --gpu-count 8 --all
+#
+# Prerequisites:
+#   - Docker with NVIDIA GPU support (nvidia-container-toolkit)
+#   - HuggingFace cache at ~/.cache/huggingface (or set --hf-cache)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Defaults
+NB_STEPS=100
+N_SEEDS=5
+SEED_PREFIX=20241106
+AGENT_TYPE="zero-shot"
+CONTEXT_LIMIT=100
+GPU_COUNT=1
+WANDB=false
+WANDB_PROJECT="${WANDB_PROJECT:-tales}"
+WANDB_ENTITY="${WANDB_ENTITY:-}"
+REASONING_PARSER=""
+REASONING_EFFORT=""
+MAX_MODEL_LEN=""
+DP_SIZE=""
+MOE_BACKEND=""
+SERVER_TYPE="vllm"
+SERVER_ARGS=""
+FORCE_FAILED=false
+CONTINUE_FROM=""
+PARALLEL=0
+HF_CACHE="${HF_HOME:-${HOME}/.cache/huggingface}"
+DOCKER_IMAGE=""
+BUILD=true
+DETACH=false
+EXTRA_DOCKER_ARGS=""
+
+# Parse args
+ENVS=""
+MODEL_NAME=""
+ALL_ENVS=false
+
+usage() {
+    echo "Usage: $0 --model MODEL [options]"
+    echo ""
+    echo "Required:"
+    echo "  --model MODEL          HuggingFace model name"
+    echo ""
+    echo "Environment selection (one required):"
+    echo "  --envs ENV [ENV...]    Specific game environments"
+    echo "  --framework FW         All games in a framework (jericho, scienceworld, etc.)"
+    echo "  --all                  All 122 games"
+    echo ""
+    echo "Benchmark options:"
+    echo "  --nb-steps N           Max steps per game (default: 100)"
+    echo "  --n-seeds N            Number of seeds (default: 5)"
+    echo "  --seed-prefix PREFIX   Seed prefix (default: 20241106)"
+    echo "  --agent-type TYPE      Agent type: zero-shot, reasoning (default: zero-shot)"
+    echo "  --context N            Context limit (default: 100)"
+    echo "  --reasoning-effort E   Max thinking tokens for reasoning agent"
+    echo "  --parallel N           Concurrency (0=all seeds, 1=sequential, N=cap)"
+    echo "  --continue-from ID     Resume from WandB run (or 'auto')"
+    echo "  --force-failed         Re-run only failed experiments"
+    echo ""
+    echo "Server options:"
+    echo "  --server TYPE          Inference server: vllm or sglang (default: vllm)"
+    echo "  --gpu-count N          Number of GPUs (default: 1)"
+    echo "  --dp-size N            Data parallel size (TP = gpu-count / dp-size)"
+    echo "  --max-model-len N      Max context length for the server"
+    echo "  --moe-backend BACKEND  vLLM MoE backend (triton, auto)"
+    echo "  --server-args ARGS     Extra CLI args for the inference server"
+    echo "  --reasoning-parser P   vLLM reasoning parser (e.g., deepseek_r1)"
+    echo ""
+    echo "Docker options:"
+    echo "  --docker-image IMG     Use specific image (skip build)"
+    echo "  --no-build             Don't rebuild image"
+    echo "  --hf-cache PATH        HuggingFace cache dir (default: ~/.cache/huggingface)"
+    echo "  --detach               Run container in background"
+    echo ""
+    echo "Logging:"
+    echo "  --wandb                Enable WandB logging"
+    echo "  --no-wandb             Disable WandB logging (default)"
+    echo ""
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --model) MODEL_NAME="$2"; shift 2 ;;
+        --envs) shift; while [[ $# -gt 0 && ! "$1" == --* ]]; do ENVS="${ENVS} $1"; shift; done; ENVS="${ENVS# }" ;;
+        --framework) ENVS="$2"; shift 2 ;;
+        --all) ALL_ENVS=true; shift ;;
+        --nb-steps) NB_STEPS="$2"; shift 2 ;;
+        --n-seeds) N_SEEDS="$2"; shift 2 ;;
+        --seed-prefix) SEED_PREFIX="$2"; shift 2 ;;
+        --agent-type) AGENT_TYPE="$2"; shift 2 ;;
+        --context) CONTEXT_LIMIT="$2"; shift 2 ;;
+        --gpu-count) GPU_COUNT="$2"; shift 2 ;;
+        --dp-size) DP_SIZE="$2"; shift 2 ;;
+        --docker-image) DOCKER_IMAGE="$2"; BUILD=false; shift 2 ;;
+        --no-build) BUILD=false; shift ;;
+        --reasoning-parser) REASONING_PARSER="$2"; shift 2 ;;
+        --reasoning-effort) REASONING_EFFORT="$2"; shift 2 ;;
+        --max-model-len) MAX_MODEL_LEN="$2"; shift 2 ;;
+        --moe-backend) MOE_BACKEND="$2"; shift 2 ;;
+        --server) SERVER_TYPE="$2"; shift 2 ;;
+        --server-args) SERVER_ARGS="$2"; shift 2 ;;
+        --continue-from) CONTINUE_FROM="$2"; shift 2 ;;
+        --force-failed) FORCE_FAILED=true; shift ;;
+        --parallel) PARALLEL="$2"; shift 2 ;;
+        --wandb) WANDB=true; shift ;;
+        --no-wandb) WANDB=false; shift ;;
+        --hf-cache) HF_CACHE="$2"; shift 2 ;;
+        --detach) DETACH=true; shift ;;
+        -h|--help) usage ;;
+        *) echo "Unknown option: $1"; usage ;;
+    esac
+done
+
+if [ -z "$MODEL_NAME" ]; then
+    echo "ERROR: --model is required"
+    usage
+fi
+
+# Validate server type
+if [ "$SERVER_TYPE" != "vllm" ] && [ "$SERVER_TYPE" != "sglang" ]; then
+    echo "ERROR: --server must be 'vllm' or 'sglang', got '${SERVER_TYPE}'"
+    exit 1
+fi
+
+# Resolve environments
+if [ "$ALL_ENVS" = true ]; then
+    ENVS="jericho scienceworld textworld textworld_express alfworld"
+fi
+
+if [ -z "$ENVS" ]; then
+    echo "ERROR: No environments specified. Use --envs, --framework, or --all"
+    usage
+fi
+
+# Determine Docker image
+if [ -z "$DOCKER_IMAGE" ]; then
+    if [ "$SERVER_TYPE" = "sglang" ]; then
+        DOCKER_IMAGE="tales-sglang"
+    else
+        DOCKER_IMAGE="tales"
+    fi
+fi
+
+# Build image if requested
+DOCKERFILE="docker/Dockerfile"
+if [ "$SERVER_TYPE" = "sglang" ]; then
+    DOCKERFILE="docker/Dockerfile.sglang"
+fi
+
+if [ "$BUILD" = true ]; then
+    echo "Building ${DOCKER_IMAGE} from ${DOCKERFILE}..."
+    docker build -f "$SCRIPT_DIR/$DOCKERFILE" -t "$DOCKER_IMAGE" "$SCRIPT_DIR"
+    echo ""
+fi
+
+# Build docker run command
+DOCKER_CMD="docker run --rm"
+
+if [ "$DETACH" = true ]; then
+    DOCKER_CMD="${DOCKER_CMD} -d"
+else
+    DOCKER_CMD="${DOCKER_CMD} -it"
+fi
+
+# GPU access
+DOCKER_CMD="${DOCKER_CMD} --gpus all"
+
+# Mount HuggingFace cache
+DOCKER_CMD="${DOCKER_CMD} -v ${HF_CACHE}:/root/.cache/huggingface"
+
+# Environment variables
+DOCKER_CMD="${DOCKER_CMD} -e MODEL_NAME=${MODEL_NAME}"
+DOCKER_CMD="${DOCKER_CMD} -e SERVER_TYPE=${SERVER_TYPE}"
+DOCKER_CMD="${DOCKER_CMD} -e GPU_COUNT=${GPU_COUNT}"
+DOCKER_CMD="${DOCKER_CMD} -e NB_STEPS=${NB_STEPS}"
+DOCKER_CMD="${DOCKER_CMD} -e N_SEEDS=${N_SEEDS}"
+DOCKER_CMD="${DOCKER_CMD} -e SEED_PREFIX=${SEED_PREFIX}"
+DOCKER_CMD="${DOCKER_CMD} -e AGENT_TYPE=${AGENT_TYPE}"
+DOCKER_CMD="${DOCKER_CMD} -e CONTEXT_LIMIT=${CONTEXT_LIMIT}"
+DOCKER_CMD="${DOCKER_CMD} -e ENVS=${ENVS}"
+DOCKER_CMD="${DOCKER_CMD} -e PARALLEL=${PARALLEL}"
+DOCKER_CMD="${DOCKER_CMD} -e CONVERSATION=true"
+
+if [ -n "$DP_SIZE" ]; then
+    DOCKER_CMD="${DOCKER_CMD} -e DP_SIZE=${DP_SIZE}"
+fi
+if [ -n "$MAX_MODEL_LEN" ]; then
+    DOCKER_CMD="${DOCKER_CMD} -e MAX_MODEL_LEN=${MAX_MODEL_LEN}"
+fi
+if [ -n "$MOE_BACKEND" ]; then
+    DOCKER_CMD="${DOCKER_CMD} -e VLLM_MOE_BACKEND=${MOE_BACKEND}"
+fi
+if [ -n "$SERVER_ARGS" ]; then
+    DOCKER_CMD="${DOCKER_CMD} -e SERVER_ARGS=${SERVER_ARGS}"
+fi
+if [ -n "$REASONING_PARSER" ]; then
+    DOCKER_CMD="${DOCKER_CMD} -e REASONING_PARSER=${REASONING_PARSER}"
+fi
+if [ -n "$REASONING_EFFORT" ]; then
+    DOCKER_CMD="${DOCKER_CMD} -e REASONING_EFFORT=${REASONING_EFFORT}"
+fi
+if [ "$FORCE_FAILED" = true ]; then
+    DOCKER_CMD="${DOCKER_CMD} -e FORCE_FAILED=true"
+fi
+if [ -n "$CONTINUE_FROM" ]; then
+    DOCKER_CMD="${DOCKER_CMD} -e CONTINUE_FROM=${CONTINUE_FROM}"
+fi
+
+# WandB
+if [ "$WANDB" = true ]; then
+    DOCKER_CMD="${DOCKER_CMD} -e WANDB=true"
+    if [ -n "$WANDB_API_KEY" ]; then
+        DOCKER_CMD="${DOCKER_CMD} -e WANDB_API_KEY=${WANDB_API_KEY}"
+    fi
+    if [ -n "$WANDB_PROJECT" ]; then
+        DOCKER_CMD="${DOCKER_CMD} -e WANDB_PROJECT=${WANDB_PROJECT}"
+    fi
+    if [ -n "$WANDB_ENTITY" ]; then
+        DOCKER_CMD="${DOCKER_CMD} -e WANDB_ENTITY=${WANDB_ENTITY}"
+    fi
+fi
+
+# HuggingFace token
+if [ -n "$HF_TOKEN" ]; then
+    DOCKER_CMD="${DOCKER_CMD} -e HF_TOKEN=${HF_TOKEN}"
+fi
+
+# SHM size for multi-GPU (NCCL needs shared memory)
+if [ "$GPU_COUNT" -gt 1 ] 2>/dev/null; then
+    DOCKER_CMD="${DOCKER_CMD} --shm-size=16g"
+fi
+
+# Image name
+DOCKER_CMD="${DOCKER_CMD} ${DOCKER_IMAGE}"
+
+echo "=== TALES Experiment (local Docker) ==="
+echo "Model:      ${MODEL_NAME}"
+echo "Agent:      ${AGENT_TYPE}"
+echo "Server:     ${SERVER_TYPE}"
+echo "Steps:      ${NB_STEPS}"
+echo "Seeds:      ${N_SEEDS} (prefix: ${SEED_PREFIX})"
+echo "Envs:       ${ENVS}"
+echo "Image:      ${DOCKER_IMAGE}"
+echo "GPUs:       ${GPU_COUNT}"
+[ -n "$DP_SIZE" ] && echo "DP size:    ${DP_SIZE} (TP=$((GPU_COUNT / DP_SIZE)))"
+echo "Parallel:   ${PARALLEL}"
+echo "Wandb:      ${WANDB}"
+[ -n "$REASONING_EFFORT" ] && echo "Reasoning:  effort=${REASONING_EFFORT}"
+[ -n "$MAX_MODEL_LEN" ] && echo "MaxLen:     ${MAX_MODEL_LEN}"
+echo ""
+echo "Command:"
+echo "  ${DOCKER_CMD}"
+echo ""
+
+exec ${DOCKER_CMD}

--- a/scripts/sanity_check.py
+++ b/scripts/sanity_check.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Sanity check: verify a vLLM-served model produces non-empty thinking traces.
+
+Runs a single game-like prompt and checks that the reasoning agent's
+thinking extraction logic yields non-empty thinking text. This catches
+configuration issues (wrong parser, missing enable_thinking, token budget
+problems) before committing to a full 5-seed benchmark run.
+
+Usage (inside container after vLLM is ready):
+    python scripts/sanity_check.py --model MODEL_NAME [--server-url URL]
+
+Exit codes:
+    0 = thinking traces extracted successfully
+    1 = no thinking traces (configuration issue)
+    2 = server error / model not responding
+"""
+
+import argparse
+import os
+import re
+import sys
+import time
+
+from openai import OpenAI
+
+_THINK_RE = re.compile(r"<think>(.*?)</think>", re.DOTALL)
+_GEMMA_CHANNEL_RE = re.compile(r"<\|channel>thought\n(.*?)<channel\|>", re.DOTALL)
+
+TEST_PROMPT = (
+    "You are playing a text-based game and your goal is to finish it with "
+    "the highest score. Upon reading the text observation, provide a *single* "
+    "short phrase to interact with the game, e.g. `get lamp` (without the backticks)."
+)
+
+THINKING_INSTRUCTION = (
+    "\n\nYour thinking process must follow the template below:\n"
+    "<think>\n"
+    "Your thoughts or draft.\n"
+    "</think>\n\n"
+    "After thinking, provide ONLY the game command."
+)
+
+# Models that need explicit thinking instructions in the prompt
+NEEDS_THINK_INSTRUCTION = ["nemotron", "magistral", "mistral-small", "mistral-large"]
+
+TEST_OBSERVATION = (
+    "You are standing in an open field west of a white house, with a boarded "
+    "front door. There is a small mailbox here."
+)
+
+
+def extract_thinking(msg, model_name: str) -> tuple[str, str]:
+    """Extract thinking and action from a chat completion message.
+
+    Mirrors the extraction logic in agents/reasoning.py _act_vllm().
+    Returns (thinking, action).
+    """
+    thinking = (
+        getattr(msg, "reasoning", None)
+        or getattr(msg, "reasoning_content", None)
+        or None
+    )
+    action = (msg.content or "").strip()
+
+    # Fallback: parse <think> tags
+    if thinking is None and ("<think>" in action or "</think>" in action):
+        closed_blocks = _THINK_RE.findall(action)
+        if closed_blocks:
+            non_empty = [b.strip() for b in closed_blocks if b.strip()]
+            thinking = "\n\n".join(non_empty) if non_empty else ""
+            action = _THINK_RE.sub("", action).strip()
+        elif "</think>" in action:
+            parts = action.split("</think>", 1)
+            thinking = parts[0].strip()
+            action = parts[1].strip() if len(parts) > 1 else ""
+
+    # Fallback: gemma4 channel tokens
+    if thinking is None and "<|channel>" in action:
+        m = _GEMMA_CHANNEL_RE.search(action)
+        if m:
+            thinking = m.group(1).strip()
+            action = _GEMMA_CHANNEL_RE.sub("", action).strip()
+            for tag in ("<|channel>", "<channel|>", "<|turn>", "<turn|>"):
+                action = action.replace(tag, "")
+            action = action.strip()
+
+    return thinking or "", action
+
+
+def run_check(model: str, server_url: str, reasoning_parser: str) -> bool:
+    """Run a single inference and verify thinking is produced."""
+    client = OpenAI(base_url=server_url, api_key="not-needed")
+
+    # Build system prompt — add thinking instruction for models that need it
+    system_prompt = TEST_PROMPT
+    if any(m in model.lower() for m in NEEDS_THINK_INSTRUCTION):
+        system_prompt += THINKING_INSTRUCTION
+
+    # Build request matching reasoning agent behavior
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": TEST_OBSERVATION},
+    ]
+
+    extra_body = {}
+    is_gptoss = "gpt-oss" in model.lower()
+    is_gemma4 = "gemma-4" in model.lower() or "gemma4" in model.lower()
+    needs_instruction = any(m in model.lower() for m in NEEDS_THINK_INSTRUCTION)
+
+    if is_gptoss:
+        extra_body["chat_template_kwargs"] = {"reasoning_effort": "high"}
+    elif not needs_instruction:
+        # Models with parser support: use enable_thinking + budget
+        extra_body.setdefault("chat_template_kwargs", {})["enable_thinking"] = True
+        if reasoning_parser:
+            extra_body["thinking_token_budget"] = 1024
+
+    if is_gemma4:
+        extra_body["skip_special_tokens"] = False
+
+    kwargs = {
+        "temperature": 0.0,
+        "seed": 42,
+        "max_tokens": 1536,
+    }
+    if extra_body:
+        kwargs["extra_body"] = extra_body
+
+    print(f"  Model: {model}")
+    print(f"  Server: {server_url}")
+    print(f"  Parser: {reasoning_parser or '(none)'}")
+    print(f"  extra_body: {extra_body}")
+    print()
+
+    try:
+        t0 = time.time()
+        response = client.chat.completions.create(
+            model=model, messages=messages, **kwargs
+        )
+        elapsed = time.time() - t0
+    except Exception as e:
+        print(f"  ❌ Server error: {e}", file=sys.stderr)
+        return False
+
+    msg = response.choices[0].message
+    thinking, action = extract_thinking(msg, model)
+
+    # Display results
+    print(f"  Response time: {elapsed:.1f}s")
+    print(f"  Finish reason: {response.choices[0].finish_reason}")
+    print(
+        f"  API reasoning field: {repr((getattr(msg, 'reasoning', None) or getattr(msg, 'reasoning_content', None) or '')[:100])}"
+    )
+    print(f"  Raw content (first 200): {repr((msg.content or '')[:200])}")
+    print()
+    print(f"  Extracted thinking ({len(thinking)} chars): {repr(thinking[:200])}")
+    print(f"  Extracted action: {repr(action[:100])}")
+    print()
+
+    if thinking and len(thinking) > 10:
+        print(f"  ✅ PASS — thinking traces present ({len(thinking)} chars)")
+        return True
+    else:
+        print(f"  ❌ FAIL — no thinking traces extracted")
+        if not action:
+            print(f"     (also no action — model may not be responding properly)")
+        return False
+
+
+def wait_for_server(server_url: str, timeout: int = 300) -> bool:
+    """Wait for vLLM server to be ready."""
+    import urllib.error
+    import urllib.request
+
+    health_url = server_url.rstrip("/v1").rstrip("/") + "/health"
+    models_url = server_url + "/models"
+    start = time.time()
+
+    while time.time() - start < timeout:
+        try:
+            urllib.request.urlopen(models_url, timeout=5)
+            return True
+        except (urllib.error.URLError, OSError):
+            time.sleep(2)
+
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Sanity check thinking traces")
+    parser.add_argument("--model", required=True, help="Model name (as served)")
+    parser.add_argument(
+        "--server-url",
+        default=os.environ.get("SERVER_URL", "http://localhost:8000/v1"),
+        help="vLLM server URL",
+    )
+    parser.add_argument(
+        "--reasoning-parser",
+        default=os.environ.get("REASONING_PARSER", ""),
+        help="Reasoning parser configured on server",
+    )
+    parser.add_argument(
+        "--wait", action="store_true", help="Wait for server to be ready"
+    )
+    parser.add_argument(
+        "--timeout", type=int, default=300, help="Server wait timeout (seconds)"
+    )
+    args = parser.parse_args()
+
+    print("=" * 60)
+    print("TALES Thinking Trace Sanity Check")
+    print("=" * 60)
+    print()
+
+    if args.wait:
+        print(f"  Waiting for server at {args.server_url}...")
+        if not wait_for_server(args.server_url, args.timeout):
+            print(f"  ❌ Server not ready after {args.timeout}s", file=sys.stderr)
+            sys.exit(2)
+        print(f"  Server ready.")
+        print()
+
+    success = run_check(args.model, args.server_url, args.reasoning_parser)
+    sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tales/token.py
+++ b/tales/token.py
@@ -60,14 +60,26 @@ class HuggingFaceTokenCounter(TokenCounter):
     def __init__(self, model: str):
         self.model = model
         try:
-            self.tokenize = AutoTokenizer.from_pretrained(self.model).tokenize
-        except OSError:
-            msg = (
-                f"Tokenizer not found for model {self.model},"
-                " make sure you have access to the model"
-                " (e.g., HuggingFace API key is correctly set)."
-            )
-            raise ValueError(msg)
+            self.tokenize = AutoTokenizer.from_pretrained(
+                self.model, trust_remote_code=True
+            ).tokenize
+        except (OSError, AttributeError, Exception) as e:
+            if isinstance(e, OSError):
+                msg = (
+                    f"Tokenizer not found for model {self.model},"
+                    " make sure you have access to the model"
+                    " (e.g., HuggingFace API key is correctly set)."
+                )
+                raise ValueError(msg)
+            # Some models (e.g., DeepSeek-V4) have config issues with transformers;
+            # fall back to loading tokenizer only without full config validation.
+            try:
+                self.tokenize = AutoTokenizer.from_pretrained(
+                    self.model, trust_remote_code=True, use_fast=True
+                ).tokenize
+            except Exception:
+                # Last resort: use tiktoken cl100k_base as approximate counter
+                self.tokenize = tiktoken.get_encoding("cl100k_base").encode
 
     def __call__(self, *, messages=None, text=None):
         nb_tokens = 0

--- a/tales/token.py
+++ b/tales/token.py
@@ -13,6 +13,10 @@ def get_token_counter(model: Optional[Model] = None):
     if model is None or model.model_id == "gpt-4o":
         return OpenAITokenCounter("gpt-4o")
 
+    # When serving locally via vLLM, skip API-based counters and use HF tokenizer
+    if os.environ.get("SERVER_TYPE") == "vllm":
+        return HuggingFaceTokenCounter(model.model_id)
+
     if "claude-" in model.model_id:
         return ClaudeTokenCounter(model)
 

--- a/tales/wandb_utils.py
+++ b/tales/wandb_utils.py
@@ -9,6 +9,20 @@ import wandb
 log = logging.getLogger("tales")
 
 WANDB_PROJECT = os.environ.get("WANDB_PROJECT", "tales")
+WANDB_ENTITY = os.environ.get("WANDB_ENTITY", None)
+
+
+def _wandb_path(project=None):
+    """Return 'entity/project' path for wandb API calls."""
+    proj = project or WANDB_PROJECT
+    entity = WANDB_ENTITY
+    if "/" in proj:
+        # Already has entity/project format.
+        return proj
+    if entity:
+        return f"{entity}/{proj}"
+    return proj
+
 
 ROLLOUT_COLUMNS = [
     "Step",
@@ -29,7 +43,7 @@ ROLLOUT_COLUMNS = [
 ]
 
 
-def find_matching_run(env_name, agent_params, game_seed, project=WANDB_PROJECT):
+def find_matching_run(env_name, agent_params, game_seed, project=None):
     """Find a matching wandb run based on game and agent config fields.
 
     Searches the wandb project for finished runs that match the core experiment
@@ -72,7 +86,7 @@ def find_matching_run(env_name, agent_params, game_seed, project=WANDB_PROJECT):
         filters["config.agent_type"] = agent_type
 
     try:
-        runs = api.runs(project, filters=filters, order="-created_at")
+        runs = api.runs(_wandb_path(project), filters=filters, order="-created_at")
     except wandb.errors.CommError as e:
         log.warning(f"Failed to search wandb runs: {e}")
         return None
@@ -106,7 +120,7 @@ def find_matching_run(env_name, agent_params, game_seed, project=WANDB_PROJECT):
     return best_run.id
 
 
-def fetch_run_trajectory(run_id, project=WANDB_PROJECT):
+def fetch_run_trajectory(run_id, project=None):
     """Fetch run config and rollout trajectory from wandb.
 
     Args:
@@ -124,7 +138,7 @@ def fetch_run_trajectory(run_id, project=WANDB_PROJECT):
         ValueError: If the run or rollout data cannot be found.
     """
     api = wandb.Api()
-    run_path = f"{project}/{run_id}"
+    run_path = f"{_wandb_path(project)}/{run_id}"
     log.info(f"Fetching run {run_path} from wandb...")
 
     try:


### PR DESCRIPTION
Docker images (vLLM + SGLang):
- docker/Dockerfile: All-in-one image based on vllm/vllm-openai:latest
- docker/Dockerfile.sglang: Alternative image based on lmsysorg/sglang:latest
- docker/entrypoint.sh: Unified entrypoint supporting both inference backends (SERVER_TYPE=vllm|sglang), activity-based startup timeout, parallel execution
- docker/README.md: Comprehensive documentation with env var reference

Local runner:
- run_experiment.sh: Launch experiments via local Docker with full CLI (--model, --server, --gpu-count, --envs, --wandb, etc.)
- .dockerignore: Whitelist-based to minimize build context

Bug fixes:
- agents/reasoning.py: Fix reasoning_effort parsed as string instead of int, add DeepSeek-V4 thinking tag extraction
- benchmark.py: Handle incomplete WandB runs in continue-from logic
- tales/token.py: Improve token counting robustness
- tales/wandb_utils.py: Better handling of missing summary data